### PR TITLE
fix(EnvelopedData): Set UKM when using key agreement

### DIFF
--- a/src/main/kotlin/tech/relaycorp/relaynet/wrappers/PRNG.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/wrappers/PRNG.kt
@@ -7,3 +7,10 @@ internal fun generateRandomBigInteger(): BigInteger {
     val random = SecureRandom()
     return BigInteger(64, random)
 }
+
+internal fun generateRandomOctets(size: Int): ByteArray {
+    val random = SecureRandom()
+    val bytes = ByteArray(size)
+    random.nextBytes(bytes)
+    return bytes
+}

--- a/src/main/kotlin/tech/relaycorp/relaynet/wrappers/cms/EnvelopedData.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/wrappers/cms/EnvelopedData.kt
@@ -21,6 +21,7 @@ import org.bouncycastle.operator.jcajce.JcaAlgorithmParametersConverter
 import tech.relaycorp.relaynet.BC_PROVIDER
 import tech.relaycorp.relaynet.HashingAlgorithm
 import tech.relaycorp.relaynet.SymmetricEncryption
+import tech.relaycorp.relaynet.wrappers.generateRandomOctets
 import tech.relaycorp.relaynet.wrappers.x509.Certificate
 import java.security.KeyPair
 import java.security.PrivateKey
@@ -245,7 +246,9 @@ internal class SessionEnvelopedData(bcEnvelopedData: CMSEnvelopedData) :
                 originatorKeyPair.private,
                 originatorKeyPair.public,
                 keyWrapCipher
-            ).setProvider(BC_PROVIDER)
+            )
+                .setUserKeyingMaterial(generateRandomOctets(64))
+                .setProvider(BC_PROVIDER)
         }
     }
 

--- a/src/test/kotlin/tech/relaycorp/relaynet/wrappers/PRNGTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/wrappers/PRNGTest.kt
@@ -2,6 +2,8 @@ package tech.relaycorp.relaynet.wrappers
 
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -17,6 +19,17 @@ class PRNGTest {
                 value.bitLength() in 48..64,
                 "Value should be between 48 and 64 bits; got ${value.bitLength()}"
             )
+        }
+    }
+
+    @Nested
+    inner class GenerateRandomOctets {
+        @ParameterizedTest(name = "Output should contain {0} octets")
+        @ValueSource(ints = [32, 64, 128])
+        fun testLength(length: Int) {
+            val value = generateRandomOctets(length)
+
+            assertEquals(length, value.size)
         }
     }
 }


### PR DESCRIPTION
For security reasons and because [PKI.js requires it](https://github.com/PeculiarVentures/PKI.js/issues/335).

I couldn't write a test for the change in EnvelopedData due to https://github.com/bcgit/bc-java/issues/1043

This work is part of https://github.com/relaycorp/relayverse/issues/27
