### PR TITLE
fix(PrivateKeyStore): Namespace keys under the managed node

### DIFF
--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/CargoTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/CargoTest.kt
@@ -31,6 +31,7 @@ internal class CargoTest : RAMFSpecializationTestCase<Cargo>(
             recipientSessionKeyPair.privateKey,
             recipientSessionKeyPair.sessionKey.keyId,
             CDACertPath.PRIVATE_GW.subjectPrivateAddress,
+            CDACertPath.PUBLIC_GW.subjectPrivateAddress,
         )
     }
 
@@ -38,9 +39,9 @@ internal class CargoTest : RAMFSpecializationTestCase<Cargo>(
     fun `Payload deserialization should be delegated to CargoMessageSet`() = runBlockingTest {
         val cargoMessageSet = CargoMessageSet(arrayOf("msg1".toByteArray(), "msg2".toByteArray()))
         val cargo = Cargo(
-            "https://gb.relaycorp.tech",
+            CDACertPath.PRIVATE_GW.subjectPrivateAddress,
             cargoMessageSet.encrypt(recipientSessionKeyPair.sessionKey, senderSessionKeyPair),
-            CDACertPath.PRIVATE_GW
+            CDACertPath.PUBLIC_GW
         )
 
         val (payloadDeserialized) = cargo.unwrapPayload(privateKeyStore)

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/ParcelTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/ParcelTest.kt
@@ -30,6 +30,7 @@ internal class ParcelTest : RAMFSpecializationTestCase<Parcel>(
         privateKeyStore.saveSessionKey(
             recipientSessionKeyPair.privateKey,
             recipientSessionKeyPair.sessionKey.keyId,
+            PDACertPath.PRIVATE_ENDPOINT.subjectPrivateAddress,
             PDACertPath.PDA.subjectPrivateAddress,
         )
     }
@@ -38,7 +39,7 @@ internal class ParcelTest : RAMFSpecializationTestCase<Parcel>(
     fun `Payload deserialization should be delegated to ServiceMessage`() = runBlockingTest {
         val serviceMessage = ServiceMessage("the type", "the content".toByteArray())
         val parcel = Parcel(
-            "https://gb.relaycorp.tech",
+            PDACertPath.PRIVATE_ENDPOINT.subjectPrivateAddress,
             serviceMessage.encrypt(recipientSessionKeyPair.sessionKey, senderSessionKeyPair),
             PDACertPath.PDA
         )

--- a/src/test/kotlin/tech/relaycorp/relaynet/utils/MockPrivateKeyStore.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/utils/MockPrivateKeyStore.kt
@@ -7,24 +7,29 @@ class MockPrivateKeyStore(
     private val savingException: Throwable? = null,
     private val retrievalException: Throwable? = null,
 ) : PrivateKeyStore() {
-    val keys: MutableMap<String, PrivateKeyData> = mutableMapOf()
+    val keys: MutableMap<String, MutableMap<String, PrivateKeyData>> = mutableMapOf()
 
     fun clear() {
         keys.clear()
     }
 
-    override suspend fun saveKeyData(keyData: PrivateKeyData, keyId: String) {
+    override suspend fun saveKeyData(
+        keyId: String,
+        keyData: PrivateKeyData,
+        privateAddress: String,
+    ) {
         if (savingException != null) {
             throw savingException
         }
-        keys[keyId] = keyData
+        keys.putIfAbsent(privateAddress, mutableMapOf())
+        keys[privateAddress]!![keyId] = keyData
     }
 
-    override suspend fun retrieveKeyData(keyId: String): PrivateKeyData? {
+    override suspend fun retrieveKeyData(keyId: String, privateAddress: String): PrivateKeyData? {
         if (retrievalException != null) {
             throw retrievalException
         }
 
-        return keys[keyId]
+        return keys[privateAddress]?.get(keyId)
     }
 }


### PR DESCRIPTION
This is the private key store counterpart to https://github.com/relaycorp/awala-jvm/issues/181
