### PR TITLE
fix(PrivateKeyStore): Use hexadecimal encoding of key id

### DIFF
--- a/src/main/kotlin/tech/relaycorp/relaynet/keystores/PrivateKeyStore.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/keystores/PrivateKeyStore.kt
@@ -1,7 +1,7 @@
 package tech.relaycorp.relaynet.keystores
 
 import java.security.PrivateKey
-import org.bouncycastle.util.encoders.Base64
+import org.bouncycastle.util.encoders.Hex
 import tech.relaycorp.relaynet.wrappers.deserializeECKeyPair
 import tech.relaycorp.relaynet.wrappers.deserializeRSAKeyPair
 import tech.relaycorp.relaynet.wrappers.x509.Certificate
@@ -60,7 +60,7 @@ abstract class PrivateKeyStore {
         return keyData.privateKeyDer.deserializeECKeyPair().private
     }
 
-    private fun formatSessionKeyId(keyId: ByteArray) = "s-${Base64.toBase64String(keyId)}"
+    private fun formatSessionKeyId(keyId: ByteArray) = "s-${Hex.toHexString(keyId)}"
 
     @Throws(KeyStoreBackendException::class)
     protected abstract suspend fun saveKeyData(

--- a/src/test/kotlin/tech/relaycorp/relaynet/keystores/PrivateKeyStoreTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/keystores/PrivateKeyStoreTest.kt
@@ -20,7 +20,7 @@ class PrivateKeyStoreTest {
     private val identityCertificate = PDACertPath.PRIVATE_ENDPOINT
 
     private val sessionKeyGeneration = SessionKeyPair.generate()
-    private val sessionKeyIdBase64 = Hex.toHexString(sessionKeyGeneration.sessionKey.keyId)
+    private val sessionKeyIdHex = Hex.toHexString(sessionKeyGeneration.sessionKey.keyId)
 
     private val ownPrivateAddress = identityCertificate.subjectPrivateAddress
     private val peerPrivateAddress = PDACertPath.PDA.subjectPrivateAddress
@@ -105,8 +105,8 @@ class PrivateKeyStoreTest {
             )
 
             assertTrue(store.keys.containsKey(ownPrivateAddress))
-            assertTrue(store.keys[ownPrivateAddress]!!.containsKey("s-$sessionKeyIdBase64"))
-            val keyData = store.keys[ownPrivateAddress]!!["s-$sessionKeyIdBase64"]!!
+            assertTrue(store.keys[ownPrivateAddress]!!.containsKey("s-$sessionKeyIdHex"))
+            val keyData = store.keys[ownPrivateAddress]!!["s-$sessionKeyIdHex"]!!
             assertEquals(
                 sessionKeyGeneration.privateKey.encoded.asList(),
                 keyData.privateKeyDer.asList()
@@ -124,7 +124,7 @@ class PrivateKeyStoreTest {
                 ownPrivateAddress,
             )
 
-            val keyData = store.keys[ownPrivateAddress]!!["s-$sessionKeyIdBase64"]!!
+            val keyData = store.keys[ownPrivateAddress]!!["s-$sessionKeyIdHex"]!!
             assertNull(keyData.peerPrivateAddress)
         }
 
@@ -139,7 +139,7 @@ class PrivateKeyStoreTest {
                 peerPrivateAddress
             )
 
-            val keyData = store.keys[ownPrivateAddress]!!["s-$sessionKeyIdBase64"]!!
+            val keyData = store.keys[ownPrivateAddress]!!["s-$sessionKeyIdHex"]!!
             assertEquals(peerPrivateAddress, keyData.peerPrivateAddress)
         }
     }

--- a/src/test/kotlin/tech/relaycorp/relaynet/keystores/PrivateKeyStoreTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/keystores/PrivateKeyStoreTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
-import org.bouncycastle.util.encoders.Base64
+import org.bouncycastle.util.encoders.Hex
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -20,7 +20,7 @@ class PrivateKeyStoreTest {
     private val identityCertificate = PDACertPath.PRIVATE_ENDPOINT
 
     private val sessionKeyGeneration = SessionKeyPair.generate()
-    private val sessionKeyIdBase64 = Base64.toBase64String(sessionKeyGeneration.sessionKey.keyId)
+    private val sessionKeyIdBase64 = Hex.toHexString(sessionKeyGeneration.sessionKey.keyId)
 
     private val ownPrivateAddress = identityCertificate.subjectPrivateAddress
     private val peerPrivateAddress = PDACertPath.PDA.subjectPrivateAddress


### PR DESCRIPTION
Instead of base64, which can contain slashes.
