### PR TITLE
feat: Make CertificationPath a standalone message

### DIFF
--- a/src/main/kotlin/tech/relaycorp/relaynet/keystores/CertificateStore.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/keystores/CertificateStore.kt
@@ -2,6 +2,7 @@ package tech.relaycorp.relaynet.keystores
 
 import java.time.ZonedDateTime
 import org.bouncycastle.asn1.ASN1TaggedObject
+import tech.relaycorp.relaynet.pki.CertificationPath
 import tech.relaycorp.relaynet.wrappers.asn1.ASN1Exception
 import tech.relaycorp.relaynet.wrappers.asn1.ASN1Utils
 import tech.relaycorp.relaynet.wrappers.x509.Certificate

--- a/src/main/kotlin/tech/relaycorp/relaynet/pki/CertificationPath.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/pki/CertificationPath.kt
@@ -1,4 +1,4 @@
-package tech.relaycorp.relaynet.keystores
+package tech.relaycorp.relaynet.pki
 
 import tech.relaycorp.relaynet.wrappers.x509.Certificate
 


### PR DESCRIPTION
With its own serialisation.

Needed in https://github.com/relaycorp/awala-endpoint-android/pull/212

TODO:

- [ ] Implement serialisation
- [ ] Define `CertificationPath` in PKI spec.
- [ ] Implement `validate()` method, which uses `path.leafCertificate.getCertificationPat(emptySet(), listOf(path.chain.last()))`