### PR TITLE
feat: Integrate CertificationPath in CertificateRotation and CertificateStore

### DIFF
--- a/src/main/kotlin/tech/relaycorp/relaynet/keystores/CertificateStore.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/keystores/CertificateStore.kt
@@ -3,22 +3,20 @@ package tech.relaycorp.relaynet.keystores
 import java.time.ZonedDateTime
 import tech.relaycorp.relaynet.pki.CertificationPath
 import tech.relaycorp.relaynet.pki.CertificationPathException
-import tech.relaycorp.relaynet.wrappers.x509.Certificate
 
 abstract class CertificateStore {
 
     @Throws(KeyStoreBackendException::class)
     suspend fun save(
-        certificate: Certificate,
-        chain: List<Certificate> = emptyList(),
+        certificationPath: CertificationPath,
         issuerPrivateAddress: String
     ) {
-        if (certificate.expiryDate < ZonedDateTime.now()) return
+        if (certificationPath.leafCertificate.expiryDate < ZonedDateTime.now()) return
 
         saveData(
-            certificate.subjectPrivateAddress,
-            certificate.expiryDate,
-            CertificationPath(certificate, chain).serialize(),
+            certificationPath.leafCertificate.subjectPrivateAddress,
+            certificationPath.leafCertificate.expiryDate,
+            certificationPath.serialize(),
             issuerPrivateAddress
         )
     }

--- a/src/main/kotlin/tech/relaycorp/relaynet/messages/CertificateRotation.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/messages/CertificateRotation.kt
@@ -1,26 +1,10 @@
 package tech.relaycorp.relaynet.messages
 
-import org.bouncycastle.asn1.DEROctetString
-import org.bouncycastle.asn1.DERSequence
-import tech.relaycorp.relaynet.wrappers.asn1.ASN1Exception
-import tech.relaycorp.relaynet.wrappers.asn1.ASN1Utils
-import tech.relaycorp.relaynet.wrappers.x509.Certificate
-import tech.relaycorp.relaynet.wrappers.x509.CertificateException
+import tech.relaycorp.relaynet.pki.CertificationPath
+import tech.relaycorp.relaynet.pki.CertificationPathException
 
-class CertificateRotation(val subjectCertificate: Certificate, val chain: List<Certificate>) {
-    fun serialize(): ByteArray {
-        val chainSequence = ASN1Utils.makeSequence(
-            chain.map { DEROctetString(it.serialize()) }
-        )
-        val sequence = ASN1Utils.serializeSequence(
-            listOf(
-                DEROctetString(subjectCertificate.serialize()),
-                chainSequence
-            ),
-            false
-        )
-        return FORMAT_SIGNATURE + sequence
-    }
+class CertificateRotation(val certificationPath: CertificationPath) {
+    fun serialize(): ByteArray = FORMAT_SIGNATURE + certificationPath.serialize()
 
     companion object {
         private const val concreteMessageType: Byte = 0x10
@@ -43,42 +27,15 @@ class CertificateRotation(val subjectCertificate: Certificate, val chain: List<C
                 )
             }
 
-            val sequenceSerialized =
+            val certificationPathSerialized =
                 serialization.sliceArray(FORMAT_SIGNATURE.size until serialization.size)
-            val sequence = try {
-                ASN1Utils.deserializeHeterogeneousSequence(sequenceSerialized)
-            } catch (exc: ASN1Exception) {
-                throw InvalidMessageException(
-                    "Serialization does not contain valid DER sequence",
-                    exc
-                )
-            }
-            if (sequence.size < 2) {
-                throw InvalidMessageException("Sequence should contain at least 2 items")
+            val certificationPath = try {
+                CertificationPath.deserialize(certificationPathSerialized)
+            } catch (exc: CertificationPathException) {
+                throw InvalidMessageException("CertificationPath is malformed", exc)
             }
 
-            val subjectCertificate = try {
-                val certificateASN1 = ASN1Utils.getOctetString(sequence.first())
-                Certificate.deserialize(certificateASN1.octets)
-            } catch (exc: CertificateException) {
-                throw InvalidMessageException("Subject certificate is malformed", exc)
-            }
-
-            val chainSequence = try {
-                DERSequence.getInstance(sequence[1], false)
-            } catch (exc: IllegalStateException) {
-                throw InvalidMessageException("Chain is malformed", exc)
-            }
-            val chain = try {
-                chainSequence.map { DEROctetString.getInstance(it) }
-                    .map { Certificate.deserialize(it.octets) }
-            } catch (exc: CertificateException) {
-                throw InvalidMessageException("Chain contains malformed certificate", exc)
-            } catch (exc: IllegalArgumentException) {
-                throw InvalidMessageException("Chain contains malformed certificate", exc)
-            }
-
-            return CertificateRotation(subjectCertificate, chain)
+            return CertificateRotation(certificationPath)
         }
     }
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/keystores/CertificateStoreTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/keystores/CertificateStoreTest.kt
@@ -48,7 +48,7 @@ class CertificateStoreTest {
         fun `Certificate should be stored`() = runBlockingTest {
             val store = MockCertificateStore()
 
-            store.save(certificate, issuerPrivateAddress = issuerAddress)
+            store.save(CertificationPath(certificate, emptyList()), issuerAddress)
 
             assertTrue(
                 store.data.containsKey(certificate.subjectPrivateAddress to issuerAddress)
@@ -62,7 +62,7 @@ class CertificateStoreTest {
         fun `Certification path should be stored`() = runBlockingTest {
             val store = MockCertificateStore()
 
-            store.save(certificate, certificateChain, issuerAddress)
+            store.save(CertificationPath(certificate, certificateChain), issuerAddress)
 
             assertTrue(
                 store.data.containsKey(certificate.subjectPrivateAddress to issuerAddress)
@@ -82,7 +82,7 @@ class CertificateStoreTest {
         @Test
         fun `Existing certification path should be returned`() = runBlockingTest {
             val store = MockCertificateStore()
-            store.save(certificate, certificateChain, issuerAddress)
+            store.save(CertificationPath(certificate, certificateChain), issuerAddress)
 
             val certificationPath = store.retrieveLatest(
                 certificate.subjectPrivateAddress,
@@ -97,7 +97,7 @@ class CertificateStoreTest {
         fun `Existing certification path of another issuer should not be returned`() =
             runBlockingTest {
                 val store = MockCertificateStore()
-                store.save(certificate, certificateChain, issuerAddress)
+                store.save(CertificationPath(certificate, certificateChain), issuerAddress)
 
                 assertNull(
                     store.retrieveLatest(
@@ -118,8 +118,8 @@ class CertificateStoreTest {
         fun `Last to expire certificate should be returned`() = runBlockingTest {
             val store = MockCertificateStore()
 
-            store.save(certificate, certificateChain, issuerAddress)
-            store.save(aboutToExpireCertificate, certificateChain, issuerAddress)
+            store.save(CertificationPath(certificate, certificateChain), issuerAddress)
+            store.save(CertificationPath(aboutToExpireCertificate, certificateChain), issuerAddress)
 
             val certificationPath =
                 store.retrieveLatest(
@@ -145,9 +145,9 @@ class CertificateStoreTest {
         fun `All stored non-expired certification paths should be returned`() = runBlockingTest {
             val store = MockCertificateStore()
 
-            store.save(certificate, certificateChain, issuerAddress)
-            store.save(aboutToExpireCertificate, certificateChain, issuerAddress)
-            store.save(expiredCertificate, certificateChain, issuerAddress)
+            store.save(CertificationPath(certificate, certificateChain), issuerAddress)
+            store.save(CertificationPath(aboutToExpireCertificate, certificateChain), issuerAddress)
+            store.save(CertificationPath(expiredCertificate, certificateChain), issuerAddress)
 
             val allCertificationPaths =
                 store.retrieveAll(certificate.subjectPrivateAddress, issuerAddress)
@@ -168,8 +168,11 @@ class CertificateStoreTest {
             runBlockingTest {
                 val store = MockCertificateStore()
 
-                store.save(certificate, certificateChain, issuerAddress)
-                store.save(PDACertPath.PRIVATE_ENDPOINT, certificateChain, "another-issuer")
+                store.save(CertificationPath(certificate, certificateChain), issuerAddress)
+                store.save(
+                    CertificationPath(PDACertPath.PRIVATE_ENDPOINT, certificateChain),
+                    "another-issuer"
+                )
 
                 val allCertificationPaths =
                     store.retrieveAll(certificate.subjectPrivateAddress, issuerAddress)
@@ -200,8 +203,8 @@ class CertificateStoreTest {
         @Test
         fun `All expired certification paths are deleted`() = runBlockingTest {
             val store = MockCertificateStore()
-            store.save(expiredCertificate, certificateChain, issuerAddress)
-            store.save(expiredCertificate, certificateChain, "another-issuer")
+            store.save(CertificationPath(expiredCertificate, certificateChain), issuerAddress)
+            store.save(CertificationPath(expiredCertificate, certificateChain), "another-issuer")
 
             store.deleteExpired()
 
@@ -214,9 +217,9 @@ class CertificateStoreTest {
         @Test
         fun `All certification paths of a certain address are deleted`() = runBlockingTest {
             val store = MockCertificateStore()
-            store.save(certificate, certificateChain, issuerAddress)
-            store.save(aboutToExpireCertificate, certificateChain, issuerAddress)
-            store.save(unrelatedCertificate, certificateChain, issuerAddress)
+            store.save(CertificationPath(certificate, certificateChain), issuerAddress)
+            store.save(CertificationPath(aboutToExpireCertificate, certificateChain), issuerAddress)
+            store.save(CertificationPath(unrelatedCertificate, certificateChain), issuerAddress)
 
             store.delete(certificate.subjectPrivateAddress, issuerAddress)
 
@@ -231,8 +234,8 @@ class CertificateStoreTest {
         fun `Only certification paths of a certain address and issuer are deleted`() =
             runBlockingTest {
                 val store = MockCertificateStore()
-                store.save(certificate, certificateChain, issuerAddress)
-                store.save(certificate, certificateChain, "another-issuer")
+                store.save(CertificationPath(certificate, certificateChain), issuerAddress)
+                store.save(CertificationPath(certificate, certificateChain), "another-issuer")
 
                 store.delete(certificate.subjectPrivateAddress, issuerAddress)
 

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/CertificateRotationTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/CertificateRotationTest.kt
@@ -2,21 +2,16 @@ package tech.relaycorp.relaynet.messages
 
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import org.bouncycastle.asn1.ASN1Sequence
-import org.bouncycastle.asn1.DEROctetString
-import org.bouncycastle.asn1.DERVisibleString
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import tech.relaycorp.relaynet.pki.CertificationPath
+import tech.relaycorp.relaynet.pki.CertificationPathException
 import tech.relaycorp.relaynet.utils.PDACertPath
-import tech.relaycorp.relaynet.wrappers.asn1.ASN1Exception
-import tech.relaycorp.relaynet.wrappers.asn1.ASN1Utils
-import tech.relaycorp.relaynet.wrappers.x509.Certificate
-import tech.relaycorp.relaynet.wrappers.x509.CertificateException
 
 class CertificateRotationTest {
-    private val subjectCertificate = PDACertPath.PRIVATE_GW
-    private val issuerCertificate = PDACertPath.PUBLIC_GW
+    private val certificationPath =
+        CertificationPath(PDACertPath.PRIVATE_GW, listOf(PDACertPath.PUBLIC_GW))
 
     private val formatSignature = byteArrayOf(*"Relaynet".toByteArray(), 0x10, 0)
 
@@ -24,7 +19,7 @@ class CertificateRotationTest {
     inner class Serialize {
         @Test
         fun `Serialization should start with format signature`() {
-            val rotation = CertificateRotation(subjectCertificate, listOf(issuerCertificate))
+            val rotation = CertificateRotation(certificationPath)
 
             val serialization = rotation.serialize()
 
@@ -34,44 +29,13 @@ class CertificateRotationTest {
         }
 
         @Test
-        fun `Serialization should contain a 2-item sequence`() {
-            val rotation = CertificateRotation(subjectCertificate, listOf(issuerCertificate))
+        fun `Serialization should contain CertificationPath`() {
+            val rotation = CertificateRotation(certificationPath)
 
             val serialization = rotation.serialize()
 
-            val derSequence = serialization.slice(10 until serialization.size)
-            val sequenceItems =
-                ASN1Utils.deserializeHeterogeneousSequence(derSequence.toByteArray())
-            assertEquals(2, sequenceItems.size)
-        }
-
-        @Test
-        fun `Subject certificate should be in sequence`() {
-            val rotation = CertificateRotation(subjectCertificate, listOf(issuerCertificate))
-
-            val serialization = rotation.serialize()
-
-            val derSequence = serialization.slice(10 until serialization.size)
-            val sequenceItems =
-                ASN1Utils.deserializeHeterogeneousSequence(derSequence.toByteArray())
-            val certificateSerialized = ASN1Utils.getOctetString(sequenceItems.first()).octets
-            assertEquals(subjectCertificate, Certificate.deserialize(certificateSerialized))
-        }
-
-        @Test
-        fun `Chain certificates should be in sequence`() {
-            val rotation = CertificateRotation(subjectCertificate, listOf(issuerCertificate))
-
-            val serialization = rotation.serialize()
-
-            val derSequence = serialization.slice(10 until serialization.size)
-            val sequenceItems =
-                ASN1Utils.deserializeHeterogeneousSequence(derSequence.toByteArray())
-            val chainSequence = ASN1Sequence.getInstance(sequenceItems[1], false)
-            assertEquals(1, chainSequence.size())
-            val issuerSerialized =
-                DEROctetString.getInstance(chainSequence.first()).octets
-            assertEquals(issuerCertificate, Certificate.deserialize(issuerSerialized))
+            val pathSerialized = serialization.slice(10 until serialization.size)
+            assertEquals(certificationPath.serialize().asList(), pathSerialized.toList())
         }
     }
 
@@ -96,124 +60,33 @@ class CertificateRotationTest {
         }
 
         @Test
-        fun `Serialization should contain a DER sequence`() {
+        fun `Serialization should contain a CertificationPath`() {
             val serialization = CertificateRotation.FORMAT_SIGNATURE + byteArrayOf(1)
 
             val exception = assertThrows<InvalidMessageException> {
                 CertificateRotation.deserialize(serialization)
             }
 
-            assertEquals("Serialization does not contain valid DER sequence", exception.message)
-            assertTrue(exception.cause is ASN1Exception)
-        }
-
-        @Test
-        fun `Serialization should contain a sequence of a least 2 items`() {
-            val serialization = CertificateRotation.FORMAT_SIGNATURE + ASN1Utils.serializeSequence(
-                listOf(DERVisibleString("the subject cert")), false
-            )
-
-            val exception = assertThrows<InvalidMessageException> {
-                CertificateRotation.deserialize(serialization)
-            }
-
-            assertEquals("Sequence should contain at least 2 items", exception.message)
-        }
-
-        @Test
-        fun `Malformed subject certificate should be refused`() {
-            val serialization = CertificateRotation.FORMAT_SIGNATURE + ASN1Utils.serializeSequence(
-                listOf(
-                    DERVisibleString("malformed"), ASN1Utils.makeSequence(emptyList(), false)
-                ),
-                false
-            )
-
-            val exception = assertThrows<InvalidMessageException> {
-                CertificateRotation.deserialize(serialization)
-            }
-
-            assertEquals("Subject certificate is malformed", exception.message)
-            assertTrue(exception.cause is CertificateException)
-        }
-
-        @Test
-        fun `Malformed chain should be refused`() {
-            val serialization = CertificateRotation.FORMAT_SIGNATURE + ASN1Utils.serializeSequence(
-                listOf(
-                    DEROctetString(subjectCertificate.serialize()), DERVisibleString("malformed")
-                ),
-                false
-            )
-
-            val exception = assertThrows<InvalidMessageException> {
-                CertificateRotation.deserialize(serialization)
-            }
-
-            assertEquals("Chain is malformed", exception.message)
-            assertTrue(exception.cause is IllegalStateException)
-        }
-
-        @Test
-        fun `Malformed chain certificate should be refused`() {
-            val serialization = CertificateRotation.FORMAT_SIGNATURE + ASN1Utils.serializeSequence(
-                listOf(
-                    DEROctetString(subjectCertificate.serialize()),
-                    ASN1Utils.makeSequence(
-                        listOf(DEROctetString("malformed".toByteArray()))
-                    )
-                ),
-                false
-            )
-
-            val exception = assertThrows<InvalidMessageException> {
-                CertificateRotation.deserialize(serialization)
-            }
-
-            assertEquals("Chain contains malformed certificate", exception.message)
-            assertTrue(exception.cause is CertificateException)
-        }
-
-        @Test
-        fun `Chain certificates should be OCTET STRINGs`() {
-            val serialization = CertificateRotation.FORMAT_SIGNATURE + ASN1Utils.serializeSequence(
-                listOf(
-                    DEROctetString(subjectCertificate.serialize()),
-                    ASN1Utils.makeSequence(
-                        listOf(DERVisibleString("malformed"))
-                    )
-                ),
-                false
-            )
-
-            val exception = assertThrows<InvalidMessageException> {
-                CertificateRotation.deserialize(serialization)
-            }
-
-            assertEquals("Chain contains malformed certificate", exception.message)
-            assertTrue(exception.cause is IllegalArgumentException)
+            assertEquals("CertificationPath is malformed", exception.message)
+            assertTrue(exception.cause is CertificationPathException)
         }
 
         @Test
         fun `A new instance should be returned if serialization is valid`() {
-            val rotation = CertificateRotation(subjectCertificate, listOf(issuerCertificate))
+            val rotation = CertificateRotation(certificationPath)
             val serialization = rotation.serialize()
 
             val rotationDeserialized = CertificateRotation.deserialize(serialization)
 
-            assertEquals(subjectCertificate, rotationDeserialized.subjectCertificate)
-            assertEquals(1, rotationDeserialized.chain.size)
-            assertEquals(issuerCertificate, rotationDeserialized.chain.first())
-        }
-
-        @Test
-        fun `Chain should be empty if sub-sequence is empty`() {
-            val rotation = CertificateRotation(subjectCertificate, emptyList())
-            val serialization = rotation.serialize()
-
-            val rotationDeserialized = CertificateRotation.deserialize(serialization)
-
-            assertEquals(0, rotationDeserialized.chain.size)
+            assertEquals(
+                certificationPath.leafCertificate,
+                rotationDeserialized.certificationPath.leafCertificate
+            )
+            assertEquals(1, rotationDeserialized.certificationPath.certificateAuthorities.size)
+            assertEquals(
+                certificationPath.certificateAuthorities.first(),
+                rotationDeserialized.certificationPath.certificateAuthorities.first()
+            )
         }
     }
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/payloads/CargoMessageTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/payloads/CargoMessageTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import tech.relaycorp.relaynet.messages.CertificateRotation
 import tech.relaycorp.relaynet.messages.Parcel
 import tech.relaycorp.relaynet.messages.ParcelCollectionAck
+import tech.relaycorp.relaynet.pki.CertificationPath
 import tech.relaycorp.relaynet.utils.ID_CERTIFICATE
 import tech.relaycorp.relaynet.utils.ID_KEY_PAIR
 import tech.relaycorp.relaynet.utils.PDACertPath
@@ -38,7 +39,7 @@ class CargoMessageTest {
 
         @Test
         fun `CertificateRotation should be correctly classified as such`() {
-            val rotation = CertificateRotation(PDACertPath.PRIVATE_GW, listOf())
+            val rotation = CertificateRotation(CertificationPath(PDACertPath.PRIVATE_GW, listOf()))
             val rotationSerialization = rotation.serialize()
 
             val cargoMessage = CargoMessage(rotationSerialization)


### PR DESCRIPTION
Per https://github.com/AwalaNetwork/specs/commit/ff1e44f55703c8e82cebceaf7f00a0a6311fb1a2

JVM counterpart to https://github.com/relaycorp/relaynet-core-js/pull/445