### PR TITLE
fix(RAMF): Require private address and support public address of recipient

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,11 +41,7 @@ dependencies {
 
     // Bouncy Castle
     implementation("org.bouncycastle:bcpkix-jdk15on:$bouncyCastleVersion")
-
-    // Libraries for ASN.1 serialization. We should eventually replace jASN1 with Bouncy Castle
-    // https://github.com/relaycorp/awala-jvm/issues/25
-    implementation("com.beanit:jasn1:1.11.3")
-    implementation("org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion")
+    implementation("org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion") // ASN.1 serialization
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.junit.jupiter:junit-jupiter:$junitJuniperVersion")

--- a/docs/howto-courier.md
+++ b/docs/howto-courier.md
@@ -15,7 +15,7 @@ It is important to call the `validate()` method on any RAMF message received fro
 
 ## Delivering cargo
 
-When delivering cargo to a public gateway via a cargo relay implementation (e.g., CogRPC), you'll need to pass [`CargoRelayRequest`](/awala-jvm/api/relaynet/tech.relaycorp.relaynet/-cargo-delivery-request/) instances to it so that you can track and delete cargo as it's safely delivered to the gateway.
+When delivering cargo to an Internet gateway via a cargo relay implementation (e.g., CogRPC), you'll need to pass [`CargoRelayRequest`](/awala-jvm/api/relaynet/tech.relaycorp.relaynet/-cargo-delivery-request/) instances to it so that you can track and delete cargo as it's safely delivered to the gateway.
 
 The actual way to pass such instances will depend entirely on the cargo relay library, so make sure it read its documentation.
 

--- a/src/main/kotlin/tech/relaycorp/relaynet/PublicNodeConnectionParams.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/PublicNodeConnectionParams.kt
@@ -13,7 +13,7 @@ import tech.relaycorp.relaynet.wrappers.deserializeECPublicKey
 import tech.relaycorp.relaynet.wrappers.deserializeRSAPublicKey
 
 class PublicNodeConnectionParams(
-    val publicAddress: String,
+    val internetAddress: String,
     val identityKey: PublicKey,
     val sessionKey: SessionKey
 ) {
@@ -27,7 +27,7 @@ class PublicNodeConnectionParams(
         )
         return ASN1Utils.serializeSequence(
             listOf(
-                DERVisibleString(publicAddress),
+                DERVisibleString(internetAddress),
                 DEROctetString(identityKey.encoded),
                 sessionKeyASN1
             ),
@@ -51,10 +51,10 @@ class PublicNodeConnectionParams(
                 )
             }
 
-            val publicAddress = ASN1Utils.getVisibleString(sequence[0]).string
-            if (!DNS.isValidDomainName(publicAddress)) {
+            val internetAddress = ASN1Utils.getVisibleString(sequence[0]).string
+            if (!DNS.isValidDomainName(internetAddress)) {
                 throw InvalidNodeConnectionParams(
-                    "Public address is syntactically invalid ($publicAddress)"
+                    "Internet address is syntactically invalid ($internetAddress)"
                 )
             }
 
@@ -92,7 +92,7 @@ class PublicNodeConnectionParams(
             }
 
             return PublicNodeConnectionParams(
-                publicAddress,
+                internetAddress,
                 identityKey,
                 SessionKey(sessionKeyId, sessionPublicKey)
             )

--- a/src/main/kotlin/tech/relaycorp/relaynet/bindings/pdc/ParcelCollection.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/bindings/pdc/ParcelCollection.kt
@@ -3,7 +3,6 @@ package tech.relaycorp.relaynet.bindings.pdc
 import tech.relaycorp.relaynet.messages.InvalidMessageException
 import tech.relaycorp.relaynet.messages.Parcel
 import tech.relaycorp.relaynet.ramf.RAMFException
-import tech.relaycorp.relaynet.ramf.RecipientAddressType
 import tech.relaycorp.relaynet.wrappers.x509.Certificate
 
 /**
@@ -27,5 +26,5 @@ class ParcelCollection(
     @Throws(RAMFException::class, InvalidMessageException::class)
     fun deserializeAndValidateParcel(): Parcel =
         Parcel.deserialize(parcelSerialized)
-            .also { it.validate(RecipientAddressType.PRIVATE, trustedCertificates) }
+            .also { it.validate(trustedCertificates) }
 }

--- a/src/main/kotlin/tech/relaycorp/relaynet/keystores/CertificateStore.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/keystores/CertificateStore.kt
@@ -14,7 +14,7 @@ abstract class CertificateStore {
         if (certificationPath.leafCertificate.expiryDate < ZonedDateTime.now()) return
 
         saveData(
-            certificationPath.leafCertificate.subjectPrivateAddress,
+            certificationPath.leafCertificate.subjectId,
             certificationPath.leafCertificate.expiryDate,
             certificationPath.serialize(),
             issuerPrivateAddress

--- a/src/main/kotlin/tech/relaycorp/relaynet/keystores/CertificateStore.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/keystores/CertificateStore.kt
@@ -9,7 +9,7 @@ abstract class CertificateStore {
     @Throws(KeyStoreBackendException::class)
     suspend fun save(
         certificationPath: CertificationPath,
-        issuerPrivateAddress: String
+        issuerId: String
     ) {
         if (certificationPath.leafCertificate.expiryDate < ZonedDateTime.now()) return
 
@@ -17,31 +17,31 @@ abstract class CertificateStore {
             certificationPath.leafCertificate.subjectId,
             certificationPath.leafCertificate.expiryDate,
             certificationPath.serialize(),
-            issuerPrivateAddress
+            issuerId
         )
     }
 
     protected abstract suspend fun saveData(
-        subjectPrivateAddress: String,
+        subjectId: String,
         leafCertificateExpiryDate: ZonedDateTime,
         certificationPathData: ByteArray,
-        issuerPrivateAddress: String,
+        issuerId: String,
     )
 
     @Throws(KeyStoreBackendException::class)
     suspend fun retrieveLatest(
-        subjectPrivateAddress: String,
-        issuerPrivateAddress: String
+        subjectId: String,
+        issuerId: String
     ): CertificationPath? =
-        retrieveAll(subjectPrivateAddress, issuerPrivateAddress)
+        retrieveAll(subjectId, issuerId)
             .maxByOrNull { it.leafCertificate.expiryDate }
 
     @Throws(KeyStoreBackendException::class)
     suspend fun retrieveAll(
-        subjectPrivateAddress: String,
-        issuerPrivateAddress: String
+        subjectId: String,
+        issuerId: String
     ): List<CertificationPath> = try {
-        retrieveData(subjectPrivateAddress, issuerPrivateAddress)
+        retrieveData(subjectId, issuerId)
             .map { CertificationPath.deserialize(it) }
             .filter { it.leafCertificate.expiryDate >= ZonedDateTime.now() }
     } catch (exc: CertificationPathException) {
@@ -49,13 +49,13 @@ abstract class CertificateStore {
     }
 
     protected abstract suspend fun retrieveData(
-        subjectPrivateAddress: String,
-        issuerPrivateAddress: String
+        subjectId: String,
+        issuerId: String
     ): List<ByteArray>
 
     @Throws(KeyStoreBackendException::class)
     abstract suspend fun deleteExpired()
 
     @Throws(KeyStoreBackendException::class)
-    abstract fun delete(subjectPrivateAddress: String, issuerPrivateAddress: String)
+    abstract fun delete(subjectId: String, issuerId: String)
 }

--- a/src/main/kotlin/tech/relaycorp/relaynet/keystores/SessionPublicKeyStore.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/keystores/SessionPublicKeyStore.kt
@@ -8,12 +8,12 @@ abstract class SessionPublicKeyStore {
     @Throws(KeyStoreBackendException::class)
     suspend fun save(
         key: SessionKey,
-        peerPrivateAddress: String,
+        peerId: String,
         creationTime: ZonedDateTime = ZonedDateTime.now()
     ) {
         val creationTimestamp = creationTime.toEpochSecond()
 
-        val existingKeyData = retrieveKeyData(peerPrivateAddress)
+        val existingKeyData = retrieveKeyData(peerId)
         if (existingKeyData != null && creationTimestamp < existingKeyData.creationTimestamp) {
             return
         }
@@ -23,31 +23,31 @@ abstract class SessionPublicKeyStore {
             key.publicKey.encoded,
             creationTimestamp
         )
-        saveKeyData(keyData, peerPrivateAddress)
+        saveKeyData(keyData, peerId)
     }
 
     @Throws(KeyStoreBackendException::class)
-    suspend fun retrieve(peerPrivateAddress: String): SessionKey {
-        val keyData = retrieveKeyData(peerPrivateAddress)
-            ?: throw MissingKeyException("There is no session key for $peerPrivateAddress")
+    suspend fun retrieve(peerId: String): SessionKey {
+        val keyData = retrieveKeyData(peerId)
+            ?: throw MissingKeyException("There is no session key for $peerId")
 
         val sessionPublicKey = keyData.keyDer.deserializeECPublicKey()
         return SessionKey(keyData.keyId, sessionPublicKey)
     }
 
     /**
-     * Delete the session key for [peerPrivateAddress], if it exists.
+     * Delete the session key for [peerId], if it exists.
      */
     @Throws(KeyStoreBackendException::class)
-    abstract suspend fun delete(peerPrivateAddress: String)
+    abstract suspend fun delete(peerId: String)
 
     @Throws(KeyStoreBackendException::class)
     protected abstract suspend fun saveKeyData(
         keyData: SessionPublicKeyData,
-        peerPrivateAddress: String
+        peerId: String
     )
 
     @Throws(KeyStoreBackendException::class)
-    protected abstract suspend fun retrieveKeyData(peerPrivateAddress: String):
+    protected abstract suspend fun retrieveKeyData(peerId: String):
         SessionPublicKeyData?
 }

--- a/src/main/kotlin/tech/relaycorp/relaynet/messages/Cargo.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/messages/Cargo.kt
@@ -15,7 +15,7 @@ private val SERIALIZER = RAMFSerializer(0x43, 0x00)
  * Cargo
  */
 class Cargo(
-    recipientAddress: String,
+    recipient: Recipient,
     payload: ByteArray,
     senderCertificate: Certificate,
     messageId: String? = null,
@@ -24,7 +24,7 @@ class Cargo(
     senderCertificateChain: Set<Certificate>? = null
 ) : EncryptedRAMFMessage<CargoMessageSet>(
     SERIALIZER,
-    recipientAddress,
+    recipient,
     payload,
     senderCertificate,
     messageId,

--- a/src/main/kotlin/tech/relaycorp/relaynet/messages/CargoCollectionAuthorization.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/messages/CargoCollectionAuthorization.kt
@@ -15,7 +15,7 @@ private val SERIALIZER = RAMFSerializer(0x44, 0x00)
  * Cargo Collection Authorization (CCA)
  */
 class CargoCollectionAuthorization(
-    recipientAddress: String,
+    recipient: Recipient,
     payload: ByteArray,
     senderCertificate: Certificate,
     messageId: String? = null,
@@ -24,7 +24,7 @@ class CargoCollectionAuthorization(
     senderCertificateChain: Set<Certificate>? = null
 ) : EncryptedRAMFMessage<CargoCollectionRequest>(
     SERIALIZER,
-    recipientAddress,
+    recipient,
     payload,
     senderCertificate,
     messageId,

--- a/src/main/kotlin/tech/relaycorp/relaynet/messages/CertificateRotation.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/messages/CertificateRotation.kt
@@ -10,7 +10,7 @@ class CertificateRotation(val certificationPath: CertificationPath) {
         private const val concreteMessageType: Byte = 0x10
         private const val concreteMessageVersion: Byte = 0
         internal val FORMAT_SIGNATURE = byteArrayOf(
-            *"Relaynet".toByteArray(),
+            *"Awala".toByteArray(),
             concreteMessageType,
             concreteMessageVersion
         )

--- a/src/main/kotlin/tech/relaycorp/relaynet/messages/Parcel.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/messages/Parcel.kt
@@ -15,7 +15,7 @@ internal val PARCEL_SERIALIZER = RAMFSerializer(0x50, 0x00)
  * Parcel
  */
 class Parcel(
-    recipientAddress: String,
+    recipient: Recipient,
     payload: ByteArray,
     senderCertificate: Certificate,
     messageId: String? = null,
@@ -24,7 +24,7 @@ class Parcel(
     senderCertificateChain: Set<Certificate>? = null
 ) : EncryptedRAMFMessage<ServiceMessage>(
     PARCEL_SERIALIZER,
-    recipientAddress,
+    recipient,
     payload,
     senderCertificate,
     messageId,

--- a/src/main/kotlin/tech/relaycorp/relaynet/messages/ParcelCollectionAck.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/messages/ParcelCollectionAck.kt
@@ -8,8 +8,8 @@ import tech.relaycorp.relaynet.wrappers.asn1.ASN1Utils
  * Parcel Collection Acknowledgement (PCA).
  */
 class ParcelCollectionAck(
-    val senderEndpointPrivateAddress: String,
-    val recipientEndpointAddress: String,
+    val senderEndpointId: String,
+    val recipientEndpointId: String,
     val parcelId: String
 ) {
     /**
@@ -18,8 +18,8 @@ class ParcelCollectionAck(
     fun serialize(): ByteArray {
         val sequence = ASN1Utils.serializeSequence(
             listOf(
-                DERVisibleString(senderEndpointPrivateAddress),
-                DERVisibleString(recipientEndpointAddress),
+                DERVisibleString(senderEndpointId),
+                DERVisibleString(recipientEndpointId),
                 DERVisibleString(parcelId)
             ),
             false

--- a/src/main/kotlin/tech/relaycorp/relaynet/messages/ParcelCollectionAck.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/messages/ParcelCollectionAck.kt
@@ -31,7 +31,7 @@ class ParcelCollectionAck(
         private const val concreteMessageType: Byte = 0x51
         private const val concreteMessageVersion: Byte = 0
         internal val FORMAT_SIGNATURE = byteArrayOf(
-            *"Relaynet".toByteArray(),
+            *"Awala".toByteArray(),
             concreteMessageType,
             concreteMessageVersion
         )
@@ -41,14 +41,15 @@ class ParcelCollectionAck(
          */
         @Throws(InvalidMessageException::class)
         fun deserialize(serialization: ByteArray): ParcelCollectionAck {
-            if (serialization.size < 10) {
+            if (serialization.size < 7) {
                 throw InvalidMessageException("Message is too short to contain format signature")
             }
-            val formatSignature = serialization.slice(0..9)
+            val formatSignature = serialization.slice(FORMAT_SIGNATURE.indices)
             if (formatSignature != FORMAT_SIGNATURE.asList()) {
                 throw InvalidMessageException("Format signature is not that of a PCA")
             }
-            val derSequence = serialization.sliceArray(10 until serialization.size)
+            val derSequence =
+                serialization.sliceArray(FORMAT_SIGNATURE.size until serialization.size)
             val sequence = try {
                 ASN1Utils.deserializeHeterogeneousSequence(derSequence)
             } catch (exc: ASN1Exception) {

--- a/src/main/kotlin/tech/relaycorp/relaynet/messages/Recipient.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/messages/Recipient.kt
@@ -1,0 +1,78 @@
+package tech.relaycorp.relaynet.messages
+
+import org.bouncycastle.asn1.ASN1Encodable
+import org.bouncycastle.asn1.ASN1TaggedObject
+import org.bouncycastle.asn1.DERSequence
+import org.bouncycastle.asn1.DERVisibleString
+import tech.relaycorp.relaynet.ramf.RAMFException
+import tech.relaycorp.relaynet.wrappers.DNS
+import tech.relaycorp.relaynet.wrappers.asn1.ASN1Utils
+
+class Recipient(val id: String, val internetAddress: String? = null) {
+    internal fun serialize(): DERSequence {
+        val idEncoded = DERVisibleString(id)
+        val additionalFields =
+            if (internetAddress != null) listOf(DERVisibleString(internetAddress))
+            else listOf()
+        return ASN1Utils.makeSequence(listOf(idEncoded) + additionalFields, false)
+    }
+
+    companion object {
+        private const val addressMaxLength = 1024
+        private val idRegex = "^0[a-f0-9]+$".toRegex()
+
+        @Throws(RAMFException::class)
+        internal fun deserialize(serialization: ASN1Encodable): Recipient {
+            val sequence = try {
+                DERSequence.getInstance(serialization)
+            } catch (exc: IllegalArgumentException) {
+                throw RAMFException("Recipient is not a SEQUENCE", exc)
+            }
+            if (sequence.size() == 0) {
+                throw RAMFException("Recipient SEQUENCE is empty")
+            }
+            val id = deserializeId(sequence.first())
+            val internetAddress = if (1 < sequence.size())
+                deserializeInternetAddress(sequence.getObjectAt(1))
+            else
+                null
+            return Recipient(id, internetAddress)
+        }
+
+        @Throws(RAMFException::class)
+        private fun deserializeId(idRaw: ASN1Encodable): String {
+            val idEncoded = ASN1TaggedObject.getInstance(idRaw)
+            val idString = ASN1Utils.getVisibleString(idEncoded)
+            val id = idString.string
+            val length = id.length
+            if (addressMaxLength < length) {
+                throw RAMFException(
+                    "Recipient id should not span more than $addressMaxLength characters " +
+                        "(got $length)"
+                )
+            }
+            if (!idRegex.matches(id)) {
+                throw RAMFException("Recipient id is malformed ($id)")
+            }
+            return id
+        }
+
+        @Throws(RAMFException::class)
+        private fun deserializeInternetAddress(internetAddressRaw: ASN1Encodable): String {
+            val addressEncoded = ASN1TaggedObject.getInstance(internetAddressRaw)
+            val addressString = ASN1Utils.getVisibleString(addressEncoded)
+            val address = addressString.string
+            val length = address.length
+            if (addressMaxLength < length) {
+                throw RAMFException(
+                    "Internet address should not span more than $addressMaxLength characters " +
+                        "(got $length)"
+                )
+            }
+            if (!DNS.isValidDomainName(address)) {
+                throw RAMFException("Internet address is malformed ($address)")
+            }
+            return address
+        }
+    }
+}

--- a/src/main/kotlin/tech/relaycorp/relaynet/messages/control/PrivateNodeRegistration.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/messages/control/PrivateNodeRegistration.kt
@@ -13,7 +13,7 @@ import tech.relaycorp.relaynet.wrappers.x509.Certificate
 import tech.relaycorp.relaynet.wrappers.x509.CertificateException
 
 /**
- * Private node registration with its private or public gateway.
+ * Private node registration with its gateway.
  *
  * When the node is a private endpoint, the gateway must be private. When the node is a private
  * gateway, the gateway must be public.

--- a/src/main/kotlin/tech/relaycorp/relaynet/messages/payloads/CargoMessage.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/messages/payloads/CargoMessage.kt
@@ -13,8 +13,8 @@ class CargoMessage(val messageSerialized: ByteArray) {
         private set
 
     init {
-        if (10 <= messageSerialized.size) {
-            val formatSignature = messageSerialized.slice(0..9)
+        if (7 <= messageSerialized.size) {
+            val formatSignature = messageSerialized.slice(0..6)
             for (typeEnum in Type.values()) {
                 if (typeEnum.formatSignature == formatSignature) {
                     type = typeEnum

--- a/src/main/kotlin/tech/relaycorp/relaynet/nodes/NodeManager.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/nodes/NodeManager.kt
@@ -74,7 +74,7 @@ abstract class NodeManager<P : Payload>(
         val unwrapping = message.unwrapPayload(privateKeyStore)
         sessionPublicKeyStore.save(
             unwrapping.peerSessionKey,
-            message.senderCertificate.subjectPrivateAddress,
+            message.senderCertificate.subjectId,
             message.creationDate
         )
         return unwrapping.payload

--- a/src/main/kotlin/tech/relaycorp/relaynet/nodes/NodeManager.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/nodes/NodeManager.kt
@@ -16,15 +16,15 @@ abstract class NodeManager<P : Payload>(
     internal val cryptoOptions: NodeCryptoOptions,
 ) {
     suspend fun generateSessionKeyPair(
-        privateAddress: String,
-        peerPrivateAddress: String? = null
+        nodeId: String,
+        peerId: String? = null
     ): SessionKeyPair {
         val keyGeneration = SessionKeyPair.generate(this.cryptoOptions.ecdhCurve)
         privateKeyStore.saveSessionKey(
             keyGeneration.privateKey,
             keyGeneration.sessionKey.keyId,
-            privateAddress,
-            peerPrivateAddress,
+            nodeId,
+            peerId,
         )
         return keyGeneration
     }
@@ -35,17 +35,17 @@ abstract class NodeManager<P : Payload>(
      * Also store the new ephemeral session key.
      *
      * @param payload
-     * @param peerPrivateAddress
-     * @param privateAddress
+     * @param peerId
+     * @param nodeId
      */
     @Throws(MissingKeyException::class, KeyStoreBackendException::class)
     suspend fun <P : EncryptedPayload> wrapMessagePayload(
         payload: P,
-        peerPrivateAddress: String,
-        privateAddress: String,
+        peerId: String,
+        nodeId: String,
     ): ByteArray {
-        val recipientSessionKey = sessionPublicKeyStore.retrieve(peerPrivateAddress)
-        val senderSessionKeyPair = generateSessionKeyPair(privateAddress, peerPrivateAddress)
+        val recipientSessionKey = sessionPublicKeyStore.retrieve(peerId)
+        val senderSessionKeyPair = generateSessionKeyPair(nodeId, peerId)
         return payload.encrypt(
             recipientSessionKey,
             senderSessionKeyPair,

--- a/src/main/kotlin/tech/relaycorp/relaynet/pki.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/pki.kt
@@ -5,7 +5,7 @@ package tech.relaycorp.relaynet
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.time.ZonedDateTime
-import tech.relaycorp.relaynet.wrappers.privateAddress
+import tech.relaycorp.relaynet.wrappers.nodeId
 import tech.relaycorp.relaynet.wrappers.x509.Certificate
 
 /**
@@ -26,7 +26,7 @@ fun issueGatewayCertificate(
 ): Certificate {
     val isSelfIssued = issuerCertificate == null
     return Certificate.issue(
-        subjectPublicKey.privateAddress,
+        subjectPublicKey.nodeId,
         subjectPublicKey,
         issuerPrivateKey,
         validityEndDate,
@@ -54,7 +54,7 @@ fun issueEndpointCertificate(
     validityStartDate: ZonedDateTime = ZonedDateTime.now()
 ): Certificate {
     return Certificate.issue(
-        subjectPublicKey.privateAddress,
+        subjectPublicKey.nodeId,
         subjectPublicKey,
         issuerPrivateKey,
         validityEndDate,
@@ -84,7 +84,7 @@ fun issueDeliveryAuthorization(
     issuerCertificate: Certificate,
     validityStartDate: ZonedDateTime = ZonedDateTime.now()
 ): Certificate = Certificate.issue(
-    subjectPublicKey.privateAddress,
+    subjectPublicKey.nodeId,
     subjectPublicKey,
     issuerPrivateKey,
     validityEndDate,

--- a/src/main/kotlin/tech/relaycorp/relaynet/pki.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/pki.kt
@@ -9,7 +9,7 @@ import tech.relaycorp.relaynet.wrappers.nodeId
 import tech.relaycorp.relaynet.wrappers.x509.Certificate
 
 /**
- * Issue Relaynet PKI certificate to a private or public gateway.
+ * Issue Awala PKI certificate to a gateway.
  *
  * @param subjectPublicKey The public key of the subject
  * @param issuerPrivateKey The private key of the issuer

--- a/src/main/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessage.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessage.kt
@@ -158,8 +158,8 @@ abstract class RAMFMessage<P : Payload> internal constructor(
         }
 
         val recipientCertificate = certificationPath[1]
-        val recipientPrivateAddress = recipientCertificate.subjectId
-        if (recipientPrivateAddress != recipient.id) {
+        val recipientId = recipientCertificate.subjectId
+        if (recipientId != recipient.id) {
             throw InvalidMessageException("Sender is authorized by the wrong recipient")
         }
     }

--- a/src/main/kotlin/tech/relaycorp/relaynet/ramf/RAMFSerializer.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/ramf/RAMFSerializer.kt
@@ -1,12 +1,5 @@
 package tech.relaycorp.relaynet.ramf
 
-import com.beanit.jasn1.ber.BerLength
-import com.beanit.jasn1.ber.BerTag
-import com.beanit.jasn1.ber.ReverseByteArrayOutputStream
-import com.beanit.jasn1.ber.types.BerDateTime
-import com.beanit.jasn1.ber.types.BerInteger
-import com.beanit.jasn1.ber.types.BerOctetString
-import com.beanit.jasn1.ber.types.string.BerVisibleString
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
@@ -17,21 +10,23 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeParseException
 import org.bouncycastle.asn1.ASN1Integer
+import org.bouncycastle.asn1.DERGeneralizedTime
+import org.bouncycastle.asn1.DEROctetString
+import org.bouncycastle.asn1.DERVisibleString
 import tech.relaycorp.relaynet.HashingAlgorithm
 import tech.relaycorp.relaynet.crypto.SignedData
 import tech.relaycorp.relaynet.crypto.SignedDataException
+import tech.relaycorp.relaynet.messages.Recipient
 import tech.relaycorp.relaynet.wrappers.asn1.ASN1Exception
 import tech.relaycorp.relaynet.wrappers.asn1.ASN1Utils
 
 private const val OCTETS_IN_9_MIB = 9437184
 
-private val DER_SEQUENCE_TAG = BerTag(BerTag.UNIVERSAL_CLASS, BerTag.CONSTRUCTED, 16)
-
 private val UTC_ZONE_ID: ZoneId = ZoneId.of("UTC")
 
 @Suppress("ArrayInDataClass")
 private data class FieldSet(
-    val recipientAddress: String,
+    val recipient: Recipient,
     val messageId: String,
     val creationDate: ZonedDateTime,
     val ttl: Int,
@@ -66,41 +61,18 @@ internal class RAMFSerializer(val concreteMessageType: Byte, val concreteMessage
 
     @Throws(IOException::class)
     private fun serializeMessage(message: RAMFMessage<*>): ByteArray {
-        val reverseOS = ReverseByteArrayOutputStream(1000, true)
-        var codeLength = 0
-
-        codeLength += BerOctetString(message.payload).encode(reverseOS, false)
-        // write tag: CONTEXT_CLASS, PRIMITIVE, 4
-        reverseOS.write(0x84)
-        codeLength += 1
-
-        codeLength += BerInteger(message.ttl.toBigInteger()).encode(reverseOS, false)
-        // write tag: CONTEXT_CLASS, PRIMITIVE, 3
-        reverseOS.write(0x83)
-        codeLength += 1
-
         val creationTimeUtc = message.creationDate.withZoneSameInstant(UTC_ZONE_ID)
-        codeLength += BerDateTime(creationTimeUtc.format(ASN1Utils.BER_DATETIME_FORMATTER)).encode(
-            reverseOS,
+        val creationTimeUtcString = creationTimeUtc.format(ASN1Utils.BER_DATETIME_FORMATTER)
+        return ASN1Utils.serializeSequence(
+            listOf(
+                message.recipient.serialize(),
+                DERVisibleString(message.id),
+                DERGeneralizedTime(creationTimeUtcString),
+                ASN1Integer(message.ttl.toLong()),
+                DEROctetString(message.payload)
+            ),
             false
         )
-        // write tag: CONTEXT_CLASS, PRIMITIVE, 2
-        reverseOS.write(0x82)
-        codeLength += 1
-
-        codeLength += BerVisibleString(message.id).encode(reverseOS, false)
-        // write tag: CONTEXT_CLASS, PRIMITIVE, 1
-        reverseOS.write(0x81)
-        codeLength += 1
-
-        codeLength += BerVisibleString(message.recipientAddress).encode(reverseOS, false)
-        // write tag: CONTEXT_CLASS, PRIMITIVE, 0
-        reverseOS.write(0x80)
-        codeLength += 1
-
-        BerLength.encodeLength(reverseOS, codeLength)
-        DER_SEQUENCE_TAG.encode(reverseOS)
-        return reverseOS.array
     }
 
     @Throws(RAMFException::class)
@@ -156,7 +128,7 @@ internal class RAMFSerializer(val concreteMessageType: Byte, val concreteMessage
             it != cmsSignedData.signerCertificate
         }.toSet()
         return messageClazz(
-            fields.recipientAddress,
+            fields.recipient,
             fields.payload,
             cmsSignedData.signerCertificate!!, // Verification passed, so the cert is present
             fields.messageId,
@@ -179,7 +151,7 @@ internal class RAMFSerializer(val concreteMessageType: Byte, val concreteMessage
             )
         }
 
-        val recipientAddress = ASN1Utils.getVisibleString(fields[0])
+        val recipient = Recipient.deserialize(fields[0])
 
         val messageId = ASN1Utils.getVisibleString(fields[1])
 
@@ -200,7 +172,7 @@ internal class RAMFSerializer(val concreteMessageType: Byte, val concreteMessage
         val payloadDer = ASN1Utils.getOctetString(fields[4])
 
         return FieldSet(
-            recipientAddress.string,
+            recipient,
             messageId.string,
             ZonedDateTime.of(creationTime, UTC_ZONE_ID),
             ttlDer.intPositiveValueExact(),

--- a/src/main/kotlin/tech/relaycorp/relaynet/ramf/RAMFSerializer.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/ramf/RAMFSerializer.kt
@@ -40,7 +40,7 @@ private data class FieldSet(
 
 internal class RAMFSerializer(val concreteMessageType: Byte, val concreteMessageVersion: Byte) {
     val formatSignature =
-        byteArrayOf(*"Relaynet".toByteArray(), concreteMessageType, concreteMessageVersion)
+        byteArrayOf(*"Awala".toByteArray(), concreteMessageType, concreteMessageVersion)
 
     fun serialize(
         message: RAMFMessage<*>,
@@ -122,14 +122,14 @@ internal class RAMFSerializer(val concreteMessageType: Byte, val concreteMessage
             throw RAMFException("Message should not be larger than 9 MiB")
         }
 
-        if (serializationSize < 10) {
+        if (serializationSize < 7) {
             throw RAMFException("Serialization is too short to contain format signature")
         }
 
-        val magicConstant = ByteArray(8)
+        val magicConstant = ByteArray(5)
         serializationStream.read(magicConstant, 0, magicConstant.size)
-        if (magicConstant.toString(Charset.forName("ASCII")) != "Relaynet") {
-            throw RAMFException("Format signature should start with magic constant 'Relaynet'")
+        if (magicConstant.toString(Charset.forName("ASCII")) != "Awala") {
+            throw RAMFException("Format signature should start with magic constant 'Awala'")
         }
 
         val messageType = serializationStream.read()

--- a/src/main/kotlin/tech/relaycorp/relaynet/ramf/RecipientAddressType.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/ramf/RecipientAddressType.kt
@@ -1,6 +1,0 @@
-package tech.relaycorp.relaynet.ramf
-
-enum class RecipientAddressType {
-    PRIVATE,
-    PUBLIC
-}

--- a/src/main/kotlin/tech/relaycorp/relaynet/wrappers/Keys.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/wrappers/Keys.kt
@@ -106,19 +106,19 @@ fun generateECDHKeyPair(curve: ECDHCurve = ECDHCurve.P256): KeyPair {
 }
 
 /**
- * Derive private address for Relaynet node from its public key.
+ * Derive id for Awala node from its public key.
  */
-val PublicKey.privateAddress: String
+val PublicKey.nodeId: String
     get() = "0${getSHA256DigestHex(this.encoded)}"
 
 /**
- * Derive private address for Relaynet node from its private key.
+ * Derive id for Awala node from its private key.
  */
-val PrivateKey.privateAddress: String
+val PrivateKey.nodeId: String
     get() {
         val rsaPrivateKey = this as RSAPrivateCrtKey
         val keyFactory = KeyFactory.getInstance("RSA", BC_PROVIDER)
         val publicKeySpec = RSAPublicKeySpec(rsaPrivateKey.modulus, rsaPrivateKey.publicExponent)
         val publicKey = keyFactory.generatePublic(publicKeySpec)
-        return publicKey.privateAddress
+        return publicKey.nodeId
     }

--- a/src/main/kotlin/tech/relaycorp/relaynet/wrappers/x509/Certificate.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/wrappers/x509/Certificate.kt
@@ -157,9 +157,9 @@ class Certificate constructor(internal val certificateHolder: X509CertificateHol
         get() = convertCertToJava(this).publicKey
 
     /**
-     * Calculate the private address of the subject.
+     * Calculate the id of the subject.
      */
-    val subjectPrivateAddress
+    val subjectId
         get() = "0" + getSHA256DigestHex(certificateHolder.subjectPublicKeyInfo.encoded)
 
     /**

--- a/src/test/kotlin/tech/relaycorp/relaynet/PKITest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/PKITest.kt
@@ -24,7 +24,7 @@ class PKITest {
             val certificate =
                 issueGatewayCertificate(identityKeyPair.public, identityKeyPair.private, tomorrow)
 
-            assertEquals(certificate.subjectPrivateAddress, certificate.commonName)
+            assertEquals(certificate.subjectId, certificate.commonName)
         }
 
         @Test
@@ -142,7 +142,7 @@ class PKITest {
             val certificate =
                 issueEndpointCertificate(identityKeyPair.public, identityKeyPair.private, tomorrow)
 
-            assertEquals(certificate.subjectPrivateAddress, certificate.commonName)
+            assertEquals(certificate.subjectId, certificate.commonName)
         }
 
         @Test
@@ -250,7 +250,7 @@ class PKITest {
                 recipientCertificate
             )
 
-            assertEquals(certificate.subjectPrivateAddress, certificate.commonName)
+            assertEquals(certificate.subjectId, certificate.commonName)
         }
 
         @Test

--- a/src/test/kotlin/tech/relaycorp/relaynet/PKITest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/PKITest.kt
@@ -14,7 +14,7 @@ import tech.relaycorp.relaynet.utils.KeyPairSet
 import tech.relaycorp.relaynet.wrappers.generateRSAKeyPair
 
 class PKITest {
-    val identityKeyPair = KeyPairSet.PUBLIC_GW
+    val identityKeyPair = KeyPairSet.INTERNET_GW
     val tomorrow: ZonedDateTime = ZonedDateTime.now(UTC).plusDays(1)
 
     @Nested

--- a/src/test/kotlin/tech/relaycorp/relaynet/PKITest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/PKITest.kt
@@ -20,7 +20,7 @@ class PKITest {
     @Nested
     inner class IssueGatewayCertificate {
         @Test
-        fun `Subject CommonName should be set to private address of gateway`() {
+        fun `Subject CommonName should be set to id of gateway`() {
             val certificate =
                 issueGatewayCertificate(identityKeyPair.public, identityKeyPair.private, tomorrow)
 
@@ -138,7 +138,7 @@ class PKITest {
     @Nested
     inner class IssueEndpointCertificate {
         @Test
-        fun `CommonName should be set to private address of gateway`() {
+        fun `CommonName should be set to id of gateway`() {
             val certificate =
                 issueEndpointCertificate(identityKeyPair.public, identityKeyPair.private, tomorrow)
 
@@ -242,7 +242,7 @@ class PKITest {
             issueEndpointCertificate(recipientKeyPair.public, recipientKeyPair.private, tomorrow)
 
         @Test
-        fun `Subject CommonName should be set to private address of subject`() {
+        fun `Subject CommonName should be set to id of subject`() {
             val certificate = issueDeliveryAuthorization(
                 identityKeyPair.public,
                 recipientKeyPair.private,

--- a/src/test/kotlin/tech/relaycorp/relaynet/PublicNodeConnectionParamsTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/PublicNodeConnectionParamsTest.kt
@@ -18,7 +18,7 @@ import tech.relaycorp.relaynet.wrappers.asn1.ASN1Utils
 class PublicNodeConnectionParamsTest {
     val internetAddress = "foo.relaycorp.tech"
 
-    val identityKey: PublicKey = KeyPairSet.PUBLIC_GW.public
+    val identityKey: PublicKey = KeyPairSet.INTERNET_GW.public
     val sessionKey = SessionKeyPair.generate().sessionKey
 
     @Nested

--- a/src/test/kotlin/tech/relaycorp/relaynet/PublicNodeConnectionParamsTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/PublicNodeConnectionParamsTest.kt
@@ -16,7 +16,7 @@ import tech.relaycorp.relaynet.wrappers.asn1.ASN1Exception
 import tech.relaycorp.relaynet.wrappers.asn1.ASN1Utils
 
 class PublicNodeConnectionParamsTest {
-    val publicAddress = "foo.relaycorp.tech"
+    val internetAddress = "foo.relaycorp.tech"
 
     val identityKey: PublicKey = KeyPairSet.PUBLIC_GW.public
     val sessionKey = SessionKeyPair.generate().sessionKey
@@ -24,18 +24,18 @@ class PublicNodeConnectionParamsTest {
     @Nested
     inner class Serialize {
         @Test
-        fun `Public address should be serialized`() {
-            val params = PublicNodeConnectionParams(publicAddress, identityKey, sessionKey)
+        fun `Internet address should be serialized`() {
+            val params = PublicNodeConnectionParams(internetAddress, identityKey, sessionKey)
 
             val serialization = params.serialize()
 
             val sequenceASN1 = ASN1Utils.deserializeHeterogeneousSequence(serialization)
-            assertEquals(publicAddress, ASN1Utils.getVisibleString(sequenceASN1[0]).string)
+            assertEquals(internetAddress, ASN1Utils.getVisibleString(sequenceASN1[0]).string)
         }
 
         @Test
         fun `Identity key should be serialized`() {
-            val params = PublicNodeConnectionParams(publicAddress, identityKey, sessionKey)
+            val params = PublicNodeConnectionParams(internetAddress, identityKey, sessionKey)
 
             val serialization = params.serialize()
 
@@ -46,7 +46,7 @@ class PublicNodeConnectionParamsTest {
 
         @Test
         fun `Session key id should be serialized`() {
-            val params = PublicNodeConnectionParams(publicAddress, identityKey, sessionKey)
+            val params = PublicNodeConnectionParams(internetAddress, identityKey, sessionKey)
 
             val serialization = params.serialize()
 
@@ -59,7 +59,7 @@ class PublicNodeConnectionParamsTest {
 
         @Test
         fun `Session public key should be serialized`() {
-            val params = PublicNodeConnectionParams(publicAddress, identityKey, sessionKey)
+            val params = PublicNodeConnectionParams(internetAddress, identityKey, sessionKey)
 
             val serialization = params.serialize()
 
@@ -107,10 +107,10 @@ class PublicNodeConnectionParamsTest {
         }
 
         @Test
-        fun `Public address should be syntactically valid`() {
-            val malformedPublicAddress = "not really a domain name"
+        fun `Internet address should be syntactically valid`() {
+            val malformedInternetAddress = "not really a domain name"
             val invalidParams = PublicNodeConnectionParams(
-                malformedPublicAddress,
+                malformedInternetAddress,
                 identityKey,
                 sessionKey
             )
@@ -121,7 +121,7 @@ class PublicNodeConnectionParamsTest {
             }
 
             assertEquals(
-                "Public address is syntactically invalid ($malformedPublicAddress)",
+                "Internet address is syntactically invalid ($malformedInternetAddress)",
                 exception.message
             )
         }
@@ -129,7 +129,7 @@ class PublicNodeConnectionParamsTest {
         @Test
         fun `Identity key should be a valid RSA public key`() {
             val invalidParams = PublicNodeConnectionParams(
-                publicAddress,
+                internetAddress,
                 sessionKey.publicKey, // Invalid
                 sessionKey
             )
@@ -150,7 +150,7 @@ class PublicNodeConnectionParamsTest {
         fun `Session key SEQUENCE should contain at least two items`() {
             val invalidSequence = ASN1Utils.serializeSequence(
                 listOf(
-                    DERVisibleString(publicAddress),
+                    DERVisibleString(internetAddress),
                     DEROctetString(identityKey.encoded),
                     ASN1Utils.makeSequence(listOf(DERVisibleString("foo")), false)
                 ),
@@ -170,7 +170,7 @@ class PublicNodeConnectionParamsTest {
         @Test
         fun `Session key should be a valid ECDH public key`() {
             val invalidParams = PublicNodeConnectionParams(
-                publicAddress,
+                internetAddress,
                 identityKey,
                 SessionKey(sessionKey.keyId, identityKey) // Invalid
             )
@@ -189,12 +189,12 @@ class PublicNodeConnectionParamsTest {
 
         @Test
         fun `Valid serialization should be deserialized`() {
-            val params = PublicNodeConnectionParams(publicAddress, identityKey, sessionKey)
+            val params = PublicNodeConnectionParams(internetAddress, identityKey, sessionKey)
             val serialization = params.serialize()
 
             val paramsDeserialized = PublicNodeConnectionParams.deserialize(serialization)
 
-            assertEquals(publicAddress, paramsDeserialized.publicAddress)
+            assertEquals(internetAddress, paramsDeserialized.internetAddress)
             assertEquals(
                 identityKey.encoded.asList(),
                 paramsDeserialized.identityKey.encoded.asList()

--- a/src/test/kotlin/tech/relaycorp/relaynet/bindings/pdc/DetachedSignatureTypeTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/bindings/pdc/DetachedSignatureTypeTest.kt
@@ -79,8 +79,11 @@ class DetachedSignatureTypeTest {
 
         @Test
         fun `Untrusted signers should be refused`() {
-            val serialization =
-                signatureType.sign(plaintext, KeyPairSet.PUBLIC_GW.private, PDACertPath.PUBLIC_GW)
+            val serialization = signatureType.sign(
+                plaintext,
+                KeyPairSet.INTERNET_GW.private,
+                PDACertPath.INTERNET_GW
+            )
 
             val exception = assertThrows<InvalidSignatureException> {
                 signatureType.verify(serialization, plaintext, listOf(PDACertPath.PRIVATE_GW))

--- a/src/test/kotlin/tech/relaycorp/relaynet/bindings/pdc/ParcelCollectionTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/bindings/pdc/ParcelCollectionTest.kt
@@ -60,10 +60,10 @@ class ParcelCollectionTest {
             val invalidParcel = Parcel(
                 Recipient(recipientCertificate.subjectId),
                 payload,
-                PDACertPath.PUBLIC_GW // Unauthorized sender
+                PDACertPath.INTERNET_GW // Unauthorized sender
             )
             val collector = ParcelCollection(
-                invalidParcel.serialize(KeyPairSet.PUBLIC_GW.private),
+                invalidParcel.serialize(KeyPairSet.INTERNET_GW.private),
                 setOf(recipientCertificate),
                 dummyACK
             )

--- a/src/test/kotlin/tech/relaycorp/relaynet/keystores/CertificateStoreTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/keystores/CertificateStoreTest.kt
@@ -144,10 +144,9 @@ class CertificateStoreTest {
         @Test
         fun `All stored non-expired certification paths should be returned`() = runTest {
             val store = MockCertificateStore()
-
             store.save(CertificationPath(certificate, certificateChain), issuerAddress)
             store.save(CertificationPath(aboutToExpireCertificate, certificateChain), issuerAddress)
-            store.save(CertificationPath(expiredCertificate, certificateChain), issuerAddress)
+            store.forceSave(CertificationPath(expiredCertificate, certificateChain), issuerAddress)
 
             val allCertificationPaths =
                 store.retrieveAll(certificate.subjectPrivateAddress, issuerAddress)

--- a/src/test/kotlin/tech/relaycorp/relaynet/keystores/CertificateStoreTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/keystores/CertificateStoreTest.kt
@@ -22,7 +22,7 @@ class CertificateStoreTest {
 
     private val certificate = PDACertPath.PRIVATE_GW
     private val certificateChain = listOf(PDACertPath.PUBLIC_GW, PDACertPath.PUBLIC_GW)
-    private val issuerAddress = PDACertPath.PUBLIC_GW.subjectPrivateAddress
+    private val issuerAddress = PDACertPath.PUBLIC_GW.subjectId
 
     private val aboutToExpireCertificate = Certificate.issue(
         "foo",
@@ -51,10 +51,10 @@ class CertificateStoreTest {
             store.save(CertificationPath(certificate, emptyList()), issuerAddress)
 
             assertTrue(
-                store.data.containsKey(certificate.subjectPrivateAddress to issuerAddress)
+                store.data.containsKey(certificate.subjectId to issuerAddress)
             )
             val certificationPaths =
-                store.data[certificate.subjectPrivateAddress to issuerAddress]!!
+                store.data[certificate.subjectId to issuerAddress]!!
             assertEquals(1, certificationPaths.size)
         }
 
@@ -65,10 +65,10 @@ class CertificateStoreTest {
             store.save(CertificationPath(certificate, certificateChain), issuerAddress)
 
             assertTrue(
-                store.data.containsKey(certificate.subjectPrivateAddress to issuerAddress)
+                store.data.containsKey(certificate.subjectId to issuerAddress)
             )
             val certificationPaths =
-                store.data[certificate.subjectPrivateAddress to issuerAddress]!!
+                store.data[certificate.subjectId to issuerAddress]!!
             assertEquals(1, certificationPaths.size)
             assertEquals(
                 CertificationPath(certificate, certificateChain).serialize().asList(),
@@ -85,7 +85,7 @@ class CertificateStoreTest {
             store.save(CertificationPath(certificate, certificateChain), issuerAddress)
 
             val certificationPath = store.retrieveLatest(
-                certificate.subjectPrivateAddress,
+                certificate.subjectId,
                 issuerAddress
             )!!
 
@@ -101,7 +101,7 @@ class CertificateStoreTest {
 
                 assertNull(
                     store.retrieveLatest(
-                        certificate.subjectPrivateAddress,
+                        certificate.subjectId,
                         "another-address"
                     )
                 )
@@ -123,7 +123,7 @@ class CertificateStoreTest {
 
             val certificationPath =
                 store.retrieveLatest(
-                    certificate.subjectPrivateAddress,
+                    certificate.subjectId,
                     issuerAddress
                 )!!
 
@@ -149,7 +149,7 @@ class CertificateStoreTest {
             store.forceSave(CertificationPath(expiredCertificate, certificateChain), issuerAddress)
 
             val allCertificationPaths =
-                store.retrieveAll(certificate.subjectPrivateAddress, issuerAddress)
+                store.retrieveAll(certificate.subjectId, issuerAddress)
 
             assertEquals(2, allCertificationPaths.size)
             assertContains(
@@ -174,7 +174,7 @@ class CertificateStoreTest {
                 )
 
                 val allCertificationPaths =
-                    store.retrieveAll(certificate.subjectPrivateAddress, issuerAddress)
+                    store.retrieveAll(certificate.subjectId, issuerAddress)
 
                 assertEquals(1, allCertificationPaths.size)
                 assertEquals(certificate, allCertificationPaths.first().leafCertificate)
@@ -183,13 +183,13 @@ class CertificateStoreTest {
         @Test
         fun `Malformed certification path should throw error`() = runTest {
             val store = MockCertificateStore()
-            store.data[certificate.subjectPrivateAddress to issuerAddress] =
+            store.data[certificate.subjectId to issuerAddress] =
                 listOf(
                     Pair(ZonedDateTime.now().plusDays(1), "malformed".toByteArray())
                 )
 
             val exception = assertThrows<KeyStoreBackendException> {
-                store.retrieveAll(certificate.subjectPrivateAddress, issuerAddress)
+                store.retrieveAll(certificate.subjectId, issuerAddress)
             }
 
             assertEquals("Stored certification path is malformed", exception.message)
@@ -220,11 +220,11 @@ class CertificateStoreTest {
             store.save(CertificationPath(aboutToExpireCertificate, certificateChain), issuerAddress)
             store.save(CertificationPath(unrelatedCertificate, certificateChain), issuerAddress)
 
-            store.delete(certificate.subjectPrivateAddress, issuerAddress)
+            store.delete(certificate.subjectId, issuerAddress)
 
-            assertNull(store.data[certificate.subjectPrivateAddress to issuerAddress])
+            assertNull(store.data[certificate.subjectId to issuerAddress])
             assertTrue(
-                store.data[unrelatedCertificate.subjectPrivateAddress to issuerAddress]!!
+                store.data[unrelatedCertificate.subjectId to issuerAddress]!!
                     .isNotEmpty()
             )
         }
@@ -236,11 +236,11 @@ class CertificateStoreTest {
                 store.save(CertificationPath(certificate, certificateChain), issuerAddress)
                 store.save(CertificationPath(certificate, certificateChain), "another-issuer")
 
-                store.delete(certificate.subjectPrivateAddress, issuerAddress)
+                store.delete(certificate.subjectId, issuerAddress)
 
-                assertNull(store.data[certificate.subjectPrivateAddress to issuerAddress])
+                assertNull(store.data[certificate.subjectId to issuerAddress])
                 assertTrue(
-                    store.data[certificate.subjectPrivateAddress to "another-issuer"]!!.isNotEmpty()
+                    store.data[certificate.subjectId to "another-issuer"]!!.isNotEmpty()
                 )
             }
     }

--- a/src/test/kotlin/tech/relaycorp/relaynet/keystores/CertificateStoreTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/keystores/CertificateStoreTest.kt
@@ -21,8 +21,8 @@ import tech.relaycorp.relaynet.wrappers.x509.Certificate
 class CertificateStoreTest {
 
     private val certificate = PDACertPath.PRIVATE_GW
-    private val certificateChain = listOf(PDACertPath.PUBLIC_GW, PDACertPath.PUBLIC_GW)
-    private val issuerAddress = PDACertPath.PUBLIC_GW.subjectId
+    private val certificateChain = listOf(PDACertPath.INTERNET_GW, PDACertPath.INTERNET_GW)
+    private val issuerAddress = PDACertPath.INTERNET_GW.subjectId
 
     private val aboutToExpireCertificate = Certificate.issue(
         "foo",

--- a/src/test/kotlin/tech/relaycorp/relaynet/keystores/SessionPublicKeyStoreTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/keystores/SessionPublicKeyStoreTest.kt
@@ -15,7 +15,7 @@ import tech.relaycorp.relaynet.utils.MockSessionPublicKeyStore
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SessionPublicKeyStoreTest {
-    private val peerPrivateAddress = "0deadbeef"
+    private val peerId = "0deadbeef"
     private val creationTime: ZonedDateTime = ZonedDateTime.now(UTC).withNano(0)
 
     private val sessionKeyGeneration = SessionKeyPair.generate()
@@ -27,10 +27,10 @@ class SessionPublicKeyStoreTest {
         fun `Key data should be saved if there is no prior key for recipient`() = runTest {
             val store = MockSessionPublicKeyStore()
 
-            store.save(sessionKey, peerPrivateAddress)
+            store.save(sessionKey, peerId)
 
-            assertTrue(store.keys.containsKey(peerPrivateAddress))
-            val keyData = store.keys[peerPrivateAddress]!!
+            assertTrue(store.keys.containsKey(peerId))
+            val keyData = store.keys[peerId]!!
             assertEquals(sessionKey.keyId.asList(), keyData.keyId.asList())
             assertEquals(sessionKey.publicKey.encoded.asList(), keyData.keyDer.asList())
         }
@@ -39,11 +39,11 @@ class SessionPublicKeyStoreTest {
         fun `Key data should be saved if prior key is older`() = runTest {
             val store = MockSessionPublicKeyStore()
             val (oldSessionKey) = SessionKeyPair.generate()
-            store.save(oldSessionKey, peerPrivateAddress, creationTime.minusSeconds(1))
+            store.save(oldSessionKey, peerId, creationTime.minusSeconds(1))
 
-            store.save(sessionKey, peerPrivateAddress, creationTime)
+            store.save(sessionKey, peerId, creationTime)
 
-            val keyData = store.keys[peerPrivateAddress]!!
+            val keyData = store.keys[peerId]!!
             assertEquals(sessionKey.keyId.asList(), keyData.keyId.asList())
             assertEquals(sessionKey.publicKey.encoded.asList(), keyData.keyDer.asList())
             assertEquals(creationTime.toEpochSecond(), keyData.creationTimestamp)
@@ -52,12 +52,12 @@ class SessionPublicKeyStoreTest {
         @Test
         fun `Key data should not be saved if prior key is newer`() = runTest {
             val store = MockSessionPublicKeyStore()
-            store.save(sessionKey, peerPrivateAddress, creationTime)
+            store.save(sessionKey, peerId, creationTime)
 
             val (oldSessionKey) = SessionKeyPair.generate()
-            store.save(oldSessionKey, peerPrivateAddress, creationTime.minusSeconds(1))
+            store.save(oldSessionKey, peerId, creationTime.minusSeconds(1))
 
-            val keyData = store.keys[peerPrivateAddress]!!
+            val keyData = store.keys[peerId]!!
             assertEquals(sessionKey.keyId.asList(), keyData.keyId.asList())
             assertEquals(sessionKey.publicKey.encoded.asList(), keyData.keyDer.asList())
             assertEquals(creationTime.toEpochSecond(), keyData.creationTimestamp)
@@ -70,9 +70,9 @@ class SessionPublicKeyStoreTest {
                 val now = ZonedDateTime.now(UTC)
                 val store = MockSessionPublicKeyStore()
 
-                store.save(sessionKey, peerPrivateAddress)
+                store.save(sessionKey, peerId)
 
-                val keyData = store.keys[peerPrivateAddress]!!
+                val keyData = store.keys[peerId]!!
                 val creationTimestamp = keyData.creationTimestamp
                 assertTrue(now.toEpochSecond() <= creationTimestamp)
                 assertTrue(creationTimestamp <= ZonedDateTime.now(UTC).toEpochSecond())
@@ -82,9 +82,9 @@ class SessionPublicKeyStoreTest {
             fun `Any explicit time should be honored`() = runTest {
                 val store = MockSessionPublicKeyStore()
 
-                store.save(sessionKey, peerPrivateAddress, creationTime)
+                store.save(sessionKey, peerId, creationTime)
 
-                val keyData = store.keys[peerPrivateAddress]!!
+                val keyData = store.keys[peerId]!!
                 assertEquals(creationTime.toEpochSecond(), keyData.creationTimestamp)
             }
 
@@ -93,9 +93,9 @@ class SessionPublicKeyStoreTest {
                 val creationTime = ZonedDateTime.now(ZoneId.of("America/Caracas")).minusDays(1)
                 val store = MockSessionPublicKeyStore()
 
-                store.save(sessionKey, peerPrivateAddress, creationTime)
+                store.save(sessionKey, peerId, creationTime)
 
-                val keyData = store.keys[peerPrivateAddress]!!
+                val keyData = store.keys[peerId]!!
                 assertEquals(
                     creationTime.withZoneSameInstant(UTC).toEpochSecond(),
                     keyData.creationTimestamp
@@ -109,9 +109,9 @@ class SessionPublicKeyStoreTest {
         @Test
         fun `Key data should be returned if key for recipient exists`() = runTest {
             val store = MockSessionPublicKeyStore()
-            store.save(sessionKey, peerPrivateAddress, creationTime)
+            store.save(sessionKey, peerId, creationTime)
 
-            val fetchedSessionKey = store.retrieve(peerPrivateAddress)
+            val fetchedSessionKey = store.retrieve(peerId)
 
             assertEquals(sessionKey, fetchedSessionKey)
         }
@@ -121,9 +121,9 @@ class SessionPublicKeyStoreTest {
             val store = MockSessionPublicKeyStore()
 
             val exception =
-                assertThrows<MissingKeyException> { (store.retrieve(peerPrivateAddress)) }
+                assertThrows<MissingKeyException> { (store.retrieve(peerId)) }
 
-            assertEquals("There is no session key for $peerPrivateAddress", exception.message)
+            assertEquals("There is no session key for $peerId", exception.message)
         }
     }
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/CargoCollectionAuthorizationTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/CargoCollectionAuthorizationTest.kt
@@ -17,7 +17,7 @@ import tech.relaycorp.relaynet.wrappers.x509.Certificate
 internal class CargoCollectionAuthorizationTest :
     RAMFSpecializationTestCase<CargoCollectionAuthorization>(
         ::CargoCollectionAuthorization,
-        { r: String, p: ByteArray, s: Certificate -> CargoCollectionAuthorization(r, p, s) },
+        { r: Recipient, p: ByteArray, s: Certificate -> CargoCollectionAuthorization(r, p, s) },
         0x44,
         0x00,
         CargoCollectionAuthorization.Companion
@@ -32,8 +32,8 @@ internal class CargoCollectionAuthorizationTest :
         privateKeyStore.saveSessionKey(
             recipientSessionKeyPair.privateKey,
             recipientSessionKeyPair.sessionKey.keyId,
-            CDACertPath.PRIVATE_GW.subjectPrivateAddress,
-            CDACertPath.PUBLIC_GW.subjectPrivateAddress,
+            CDACertPath.PRIVATE_GW.subjectId,
+            CDACertPath.PUBLIC_GW.subjectId,
         )
     }
 
@@ -42,7 +42,7 @@ internal class CargoCollectionAuthorizationTest :
         runTest {
             val ccr = CargoCollectionRequest(CDACertPath.PUBLIC_GW)
             val cca = CargoCollectionAuthorization(
-                CDACertPath.PUBLIC_GW.subjectPrivateAddress,
+                Recipient(CDACertPath.PUBLIC_GW.subjectId),
                 ccr.encrypt(recipientSessionKeyPair.sessionKey, senderSessionKeyPair),
                 ID_CERTIFICATE
             )

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/CargoCollectionAuthorizationTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/CargoCollectionAuthorizationTest.kt
@@ -33,16 +33,16 @@ internal class CargoCollectionAuthorizationTest :
             recipientSessionKeyPair.privateKey,
             recipientSessionKeyPair.sessionKey.keyId,
             CDACertPath.PRIVATE_GW.subjectId,
-            CDACertPath.PUBLIC_GW.subjectId,
+            CDACertPath.INTERNET_GW.subjectId,
         )
     }
 
     @Test
     fun `Payload deserialization should be delegated to CargoCollectionRequest`() =
         runTest {
-            val ccr = CargoCollectionRequest(CDACertPath.PUBLIC_GW)
+            val ccr = CargoCollectionRequest(CDACertPath.INTERNET_GW)
             val cca = CargoCollectionAuthorization(
-                Recipient(CDACertPath.PUBLIC_GW.subjectId),
+                Recipient(CDACertPath.INTERNET_GW.subjectId),
                 ccr.encrypt(recipientSessionKeyPair.sessionKey, senderSessionKeyPair),
                 ID_CERTIFICATE
             )

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/CargoTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/CargoTest.kt
@@ -15,7 +15,7 @@ import tech.relaycorp.relaynet.wrappers.x509.Certificate
 @ExperimentalCoroutinesApi
 internal class CargoTest : RAMFSpecializationTestCase<Cargo>(
     ::Cargo,
-    { r: String, p: ByteArray, s: Certificate -> Cargo(r, p, s) },
+    { r: Recipient, p: ByteArray, s: Certificate -> Cargo(r, p, s) },
     0x43,
     0x00,
     Cargo.Companion
@@ -30,8 +30,8 @@ internal class CargoTest : RAMFSpecializationTestCase<Cargo>(
         privateKeyStore.saveSessionKey(
             recipientSessionKeyPair.privateKey,
             recipientSessionKeyPair.sessionKey.keyId,
-            CDACertPath.PRIVATE_GW.subjectPrivateAddress,
-            CDACertPath.PUBLIC_GW.subjectPrivateAddress,
+            CDACertPath.PRIVATE_GW.subjectId,
+            CDACertPath.PUBLIC_GW.subjectId,
         )
     }
 
@@ -39,7 +39,7 @@ internal class CargoTest : RAMFSpecializationTestCase<Cargo>(
     fun `Payload deserialization should be delegated to CargoMessageSet`() = runTest {
         val cargoMessageSet = CargoMessageSet(arrayOf("msg1".toByteArray(), "msg2".toByteArray()))
         val cargo = Cargo(
-            CDACertPath.PRIVATE_GW.subjectPrivateAddress,
+            Recipient(CDACertPath.PRIVATE_GW.subjectId),
             cargoMessageSet.encrypt(recipientSessionKeyPair.sessionKey, senderSessionKeyPair),
             CDACertPath.PUBLIC_GW
         )

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/CargoTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/CargoTest.kt
@@ -31,7 +31,7 @@ internal class CargoTest : RAMFSpecializationTestCase<Cargo>(
             recipientSessionKeyPair.privateKey,
             recipientSessionKeyPair.sessionKey.keyId,
             CDACertPath.PRIVATE_GW.subjectId,
-            CDACertPath.PUBLIC_GW.subjectId,
+            CDACertPath.INTERNET_GW.subjectId,
         )
     }
 
@@ -41,7 +41,7 @@ internal class CargoTest : RAMFSpecializationTestCase<Cargo>(
         val cargo = Cargo(
             Recipient(CDACertPath.PRIVATE_GW.subjectId),
             cargoMessageSet.encrypt(recipientSessionKeyPair.sessionKey, senderSessionKeyPair),
-            CDACertPath.PUBLIC_GW
+            CDACertPath.INTERNET_GW
         )
 
         val (payloadDeserialized) = cargo.unwrapPayload(privateKeyStore)

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/CertificateRotationTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/CertificateRotationTest.kt
@@ -11,7 +11,7 @@ import tech.relaycorp.relaynet.utils.PDACertPath
 
 class CertificateRotationTest {
     private val certificationPath =
-        CertificationPath(PDACertPath.PRIVATE_GW, listOf(PDACertPath.PUBLIC_GW))
+        CertificationPath(PDACertPath.PRIVATE_GW, listOf(PDACertPath.INTERNET_GW))
 
     private val formatSignature = byteArrayOf(*"Awala".toByteArray(), 0x10, 0)
 

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/CertificateRotationTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/CertificateRotationTest.kt
@@ -13,7 +13,7 @@ class CertificateRotationTest {
     private val certificationPath =
         CertificationPath(PDACertPath.PRIVATE_GW, listOf(PDACertPath.PUBLIC_GW))
 
-    private val formatSignature = byteArrayOf(*"Relaynet".toByteArray(), 0x10, 0)
+    private val formatSignature = byteArrayOf(*"Awala".toByteArray(), 0x10, 0)
 
     @Nested
     inner class Serialize {
@@ -24,7 +24,7 @@ class CertificateRotationTest {
             val serialization = rotation.serialize()
 
             assertEquals(
-                formatSignature.asList(), serialization.slice(0..9)
+                formatSignature.asList(), serialization.slice(0..6)
             )
         }
 
@@ -34,7 +34,7 @@ class CertificateRotationTest {
 
             val serialization = rotation.serialize()
 
-            val pathSerialized = serialization.slice(10 until serialization.size)
+            val pathSerialized = serialization.slice(7 until serialization.size)
             assertEquals(certificationPath.serialize().asList(), pathSerialized.toList())
         }
     }
@@ -44,7 +44,7 @@ class CertificateRotationTest {
         @Test
         fun `Serialization should be long enough to potentially contain format signature`() {
             val exception = assertThrows<InvalidMessageException> {
-                CertificateRotation.deserialize("RelaynetP".toByteArray())
+                CertificateRotation.deserialize("AwalaP".toByteArray())
             }
 
             assertEquals("Message is too short to contain format signature", exception.message)
@@ -53,7 +53,7 @@ class CertificateRotationTest {
         @Test
         fun `Serialization should start with format signature`() {
             val exception = assertThrows<InvalidMessageException> {
-                CertificateRotation.deserialize("RelaynetP0".toByteArray())
+                CertificateRotation.deserialize("AwalaP0".toByteArray())
             }
 
             assertEquals("Format signature is not that of a CertificateRotation", exception.message)

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/ParcelCollectionAckTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/ParcelCollectionAckTest.kt
@@ -6,12 +6,13 @@ import kotlin.test.assertTrue
 import org.bouncycastle.asn1.DERVisibleString
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertThrows
+import tech.relaycorp.relaynet.utils.RAMFStubs
 import tech.relaycorp.relaynet.wrappers.asn1.ASN1Exception
 import tech.relaycorp.relaynet.wrappers.asn1.ASN1Utils
 
 internal class ParcelCollectionAckTest {
     private val senderEndpointPrivateAddress = "0deadbeef"
-    private val recipientEndpointAddress = "https://ping.relaycorp.tech"
+    private val recipientEndpointAddress = RAMFStubs.recipientInternetAddress
     private val parcelId = "the-parcel-id"
 
     private val formatSignature = byteArrayOf(*"Awala".toByteArray(), 0x51, 0)

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/ParcelCollectionAckTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/ParcelCollectionAckTest.kt
@@ -122,7 +122,7 @@ internal class ParcelCollectionAckTest {
 
             val pca = ParcelCollectionAck.deserialize(serialization)
 
-            assertEquals(pca.senderEndpointPrivateAddress, senderEndpointPrivateAddress)
+            assertEquals(pca.senderEndpointId, senderEndpointPrivateAddress)
         }
 
         @Test
@@ -135,7 +135,7 @@ internal class ParcelCollectionAckTest {
 
             val pca = ParcelCollectionAck.deserialize(serialization)
 
-            assertEquals(pca.recipientEndpointAddress, recipientEndpointAddress)
+            assertEquals(pca.recipientEndpointId, recipientEndpointAddress)
         }
 
         @Test

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/ParcelCollectionAckTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/ParcelCollectionAckTest.kt
@@ -11,8 +11,8 @@ import tech.relaycorp.relaynet.wrappers.asn1.ASN1Exception
 import tech.relaycorp.relaynet.wrappers.asn1.ASN1Utils
 
 internal class ParcelCollectionAckTest {
-    private val senderEndpointPrivateAddress = "0deadbeef"
-    private val recipientEndpointAddress = RAMFStubs.recipientInternetAddress
+    private val senderEndpointId = "0deadbeef"
+    private val recipientEndpointId = RAMFStubs.recipientInternetAddress
     private val parcelId = "the-parcel-id"
 
     private val formatSignature = byteArrayOf(*"Awala".toByteArray(), 0x51, 0)
@@ -22,8 +22,8 @@ internal class ParcelCollectionAckTest {
         @Test
         fun `Serialization should start with format signature`() {
             val pca = ParcelCollectionAck(
-                senderEndpointPrivateAddress,
-                recipientEndpointAddress,
+                senderEndpointId,
+                recipientEndpointId,
                 parcelId
             )
 
@@ -38,8 +38,8 @@ internal class ParcelCollectionAckTest {
         @Test
         fun `ACK should be serialized as a 3-item sequence`() {
             val pca = ParcelCollectionAck(
-                senderEndpointPrivateAddress,
-                recipientEndpointAddress,
+                senderEndpointId,
+                recipientEndpointId,
                 parcelId
             )
 
@@ -50,11 +50,11 @@ internal class ParcelCollectionAckTest {
                 ASN1Utils.deserializeHeterogeneousSequence(derSequence.toByteArray())
             assertEquals(3, sequenceItems.size)
             assertEquals(
-                senderEndpointPrivateAddress,
+                senderEndpointId,
                 ASN1Utils.getVisibleString(sequenceItems[0]).string
             )
             assertEquals(
-                recipientEndpointAddress,
+                recipientEndpointId,
                 ASN1Utils.getVisibleString(sequenceItems[1]).string
             )
             assertEquals(
@@ -114,36 +114,36 @@ internal class ParcelCollectionAckTest {
         }
 
         @Test
-        fun `Sender endpoint private address should be decoded as a VisibleString`() {
+        fun `Sender endpoint id should be decoded as a VisibleString`() {
             val serialization = ParcelCollectionAck(
-                senderEndpointPrivateAddress,
-                recipientEndpointAddress,
+                senderEndpointId,
+                recipientEndpointId,
                 parcelId
             ).serialize()
 
             val pca = ParcelCollectionAck.deserialize(serialization)
 
-            assertEquals(pca.senderEndpointId, senderEndpointPrivateAddress)
+            assertEquals(pca.senderEndpointId, senderEndpointId)
         }
 
         @Test
         fun `Recipient endpoint address should be decoded as a VisibleString`() {
             val serialization = ParcelCollectionAck(
-                senderEndpointPrivateAddress,
-                recipientEndpointAddress,
+                senderEndpointId,
+                recipientEndpointId,
                 parcelId
             ).serialize()
 
             val pca = ParcelCollectionAck.deserialize(serialization)
 
-            assertEquals(pca.recipientEndpointId, recipientEndpointAddress)
+            assertEquals(pca.recipientEndpointId, recipientEndpointId)
         }
 
         @Test
         fun `Parcel id should be decoded as a VisibleString`() {
             val serialization = ParcelCollectionAck(
-                senderEndpointPrivateAddress,
-                recipientEndpointAddress,
+                senderEndpointId,
+                recipientEndpointId,
                 parcelId
             ).serialize()
 

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/ParcelCollectionAckTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/ParcelCollectionAckTest.kt
@@ -14,7 +14,7 @@ internal class ParcelCollectionAckTest {
     private val recipientEndpointAddress = "https://ping.relaycorp.tech"
     private val parcelId = "the-parcel-id"
 
-    private val formatSignature = byteArrayOf(*"Relaynet".toByteArray(), 0x51, 0)
+    private val formatSignature = byteArrayOf(*"Awala".toByteArray(), 0x51, 0)
 
     @Nested
     inner class Serialize {
@@ -30,7 +30,7 @@ internal class ParcelCollectionAckTest {
 
             assertEquals(
                 formatSignature.asList(),
-                serialization.slice(0..9)
+                serialization.slice(formatSignature.indices)
             )
         }
 
@@ -44,7 +44,7 @@ internal class ParcelCollectionAckTest {
 
             val serialization = pca.serialize()
 
-            val derSequence = serialization.slice(10 until serialization.size)
+            val derSequence = serialization.slice(7 until serialization.size)
             val sequenceItems =
                 ASN1Utils.deserializeHeterogeneousSequence(derSequence.toByteArray())
             assertEquals(3, sequenceItems.size)
@@ -68,7 +68,7 @@ internal class ParcelCollectionAckTest {
         @Test
         fun `Serialization should be long enough to potentially contain format signature`() {
             val exception = assertThrows<InvalidMessageException> {
-                ParcelCollectionAck.deserialize("RelaynetP".toByteArray())
+                ParcelCollectionAck.deserialize("AwalaP".toByteArray())
             }
 
             assertEquals("Message is too short to contain format signature", exception.message)
@@ -77,7 +77,7 @@ internal class ParcelCollectionAckTest {
         @Test
         fun `Serialization should start with format signature`() {
             val exception = assertThrows<InvalidMessageException> {
-                ParcelCollectionAck.deserialize("RelaynetP0".toByteArray())
+                ParcelCollectionAck.deserialize("AwalaP0".toByteArray())
             }
 
             assertEquals("Format signature is not that of a PCA", exception.message)

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/ParcelTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/ParcelTest.kt
@@ -15,7 +15,7 @@ import tech.relaycorp.relaynet.wrappers.x509.Certificate
 @ExperimentalCoroutinesApi
 internal class ParcelTest : RAMFSpecializationTestCase<Parcel>(
     ::Parcel,
-    { r: String, p: ByteArray, s: Certificate -> Parcel(r, p, s) },
+    { r: Recipient, p: ByteArray, s: Certificate -> Parcel(r, p, s) },
     0x50,
     0x00,
     Parcel.Companion
@@ -30,8 +30,8 @@ internal class ParcelTest : RAMFSpecializationTestCase<Parcel>(
         privateKeyStore.saveSessionKey(
             recipientSessionKeyPair.privateKey,
             recipientSessionKeyPair.sessionKey.keyId,
-            PDACertPath.PRIVATE_ENDPOINT.subjectPrivateAddress,
-            PDACertPath.PDA.subjectPrivateAddress,
+            PDACertPath.PRIVATE_ENDPOINT.subjectId,
+            PDACertPath.PDA.subjectId,
         )
     }
 
@@ -39,7 +39,7 @@ internal class ParcelTest : RAMFSpecializationTestCase<Parcel>(
     fun `Payload deserialization should be delegated to ServiceMessage`() = runTest {
         val serviceMessage = ServiceMessage("the type", "the content".toByteArray())
         val parcel = Parcel(
-            PDACertPath.PRIVATE_ENDPOINT.subjectPrivateAddress,
+            Recipient(PDACertPath.PRIVATE_ENDPOINT.subjectId),
             serviceMessage.encrypt(recipientSessionKeyPair.sessionKey, senderSessionKeyPair),
             PDACertPath.PDA
         )

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/RecipientTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/RecipientTest.kt
@@ -1,0 +1,208 @@
+package tech.relaycorp.relaynet.messages
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.bouncycastle.asn1.ASN1TaggedObject
+import org.bouncycastle.asn1.DERNull
+import org.bouncycastle.asn1.DERSequence
+import org.bouncycastle.asn1.DERVisibleString
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import tech.relaycorp.relaynet.ramf.RAMFException
+import tech.relaycorp.relaynet.utils.RAMFUtils
+import tech.relaycorp.relaynet.wrappers.asn1.ASN1Utils
+
+class RecipientTest {
+    @Nested
+    inner class Serialize {
+        @Nested
+        inner class Id {
+            @Test
+            fun `Id should be first item in sub-sequence`() {
+                val recipient = Recipient(RAMFUtils.recipientId)
+
+                val serialization = recipient.serialize()
+
+                val idEncoded = ASN1TaggedObject.getInstance(serialization.first())
+                val idString =
+                    ASN1Utils.getVisibleString(idEncoded)
+                assertEquals(recipient.id, idString.string)
+            }
+
+            @Test
+            fun `Id should be implicitly tagged`() {
+                val recipient = Recipient(RAMFUtils.recipientId)
+
+                val serialization = recipient.serialize()
+
+                val idEncoded = serialization.first() as ASN1TaggedObject
+                assertFalse(idEncoded.isExplicit)
+            }
+        }
+
+        @Nested
+        inner class InternetAddress {
+            @Test
+            fun `Internet address should be absent if unspecified`() {
+                val recipient = Recipient(RAMFUtils.recipientId)
+
+                val serialization = recipient.serialize()
+
+                assertEquals(1, serialization.size())
+            }
+
+            @Test
+            fun `Internet address should be second item in sub-sequence`() {
+                val recipient = Recipient(RAMFUtils.recipientId, RAMFUtils.recipientInternetAddress)
+
+                val serialization = recipient.serialize()
+
+                assertEquals(2, serialization.size())
+                val internetAddressEncoded = serialization.objects.toList()[1] as ASN1TaggedObject
+                val internetAddressString = ASN1Utils.getVisibleString(internetAddressEncoded)
+                assertEquals(recipient.internetAddress, internetAddressString.string)
+            }
+
+            @Test
+            fun `Internet address should be implicitly tagged`() {
+                val recipient = Recipient(RAMFUtils.recipientId, RAMFUtils.recipientInternetAddress)
+
+                val serialization = recipient.serialize()
+
+                val internetAddressEncoded = serialization.objects.toList()[1] as ASN1TaggedObject
+                assertFalse(internetAddressEncoded.isExplicit)
+            }
+        }
+    }
+
+    @Nested
+    inner class Deserialize {
+        @Test
+        fun `Serialization should be a SEQUENCE`() {
+            val exception = assertThrows<RAMFException> {
+                Recipient.deserialize(DERNull.INSTANCE)
+            }
+
+            assertEquals("Recipient is not a SEQUENCE", exception.message)
+            assertTrue(exception.cause is IllegalArgumentException)
+        }
+
+        @Test
+        fun `SEQUENCE should have at least one item`() {
+            val exception = assertThrows<RAMFException> {
+                Recipient.deserialize(DERSequence())
+            }
+
+            assertEquals("Recipient SEQUENCE is empty", exception.message)
+        }
+
+        @Nested
+        inner class Id {
+            @Test
+            fun `Id should be extracted`() {
+                val recipient = Recipient(RAMFUtils.recipientId)
+
+                val recipientDeserialized = Recipient.deserialize(recipient.serialize())
+
+                assertEquals(recipient.id, recipientDeserialized.id)
+            }
+
+            @Test
+            fun `Id of up to 1024 octets should be accepted`() {
+                val recipient = Recipient("0${"a".repeat(1023)}")
+
+                val recipientDeserialized = Recipient.deserialize(recipient.serialize())
+
+                assertEquals(recipient.id, recipientDeserialized.id)
+            }
+
+            @Test
+            fun `Id spanning more than 1024 octets should be refused`() {
+                val recipient = Recipient("0${"a".repeat(1024)}")
+                val serialization = recipient.serialize()
+
+                val exception = assertThrows<RAMFException> {
+                    Recipient.deserialize(serialization)
+                }
+
+                assertEquals(
+                    "Recipient id should not span more than 1024 characters (got 1025)",
+                    exception.message
+                )
+            }
+
+            @Test
+            fun `Malformed id should be refused`() {
+                val recipient = Recipient("not an id")
+                val serialization = recipient.serialize()
+
+                val exception = assertThrows<RAMFException> {
+                    Recipient.deserialize(serialization)
+                }
+
+                assertEquals(
+                    "Recipient id is malformed (${recipient.id})",
+                    exception.message
+                )
+            }
+        }
+
+        @Nested
+        inner class InternetAddress {
+            @Test
+            fun `Address should be null if absent`() {
+                val serialization = ASN1Utils.makeSequence(
+                    listOf(DERVisibleString(RAMFUtils.recipientId)),
+                    false,
+                )
+
+                val recipientDeserialized = Recipient.deserialize(serialization)
+
+                assertNull(recipientDeserialized.internetAddress)
+            }
+
+            @Test
+            fun `Domain name should be accepted`() {
+                val recipient = Recipient(RAMFUtils.recipientId, RAMFUtils.recipientInternetAddress)
+
+                val recipientDeserialized = Recipient.deserialize(recipient.serialize())
+
+                assertEquals(
+                    RAMFUtils.recipientInternetAddress,
+                    recipientDeserialized.internetAddress
+                )
+            }
+
+            @Test
+            fun `Address spanning more than 1024 octets should be refused`() {
+                val longDomain = "${"a".repeat(1021)}.com"
+                val recipient = Recipient(RAMFUtils.recipientId, longDomain)
+                val serialization = recipient.serialize()
+
+                val exception = assertThrows<RAMFException> { Recipient.deserialize(serialization) }
+
+                assertEquals(
+                    "Internet address should not span more than 1024 characters (got 1025)",
+                    exception.message
+                )
+            }
+
+            @Test
+            fun `Malformed domain name should be refused`() {
+                val malformedDomain = "not really a domain name"
+                val recipient = Recipient(RAMFUtils.recipientId, malformedDomain)
+                val serialization = recipient.serialize()
+
+                val exception = assertThrows<RAMFException> { Recipient.deserialize(serialization) }
+
+                assertEquals(
+                    "Internet address is malformed ($malformedDomain)",
+                    exception.message
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/payloads/CargoCollectionRequestTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/payloads/CargoCollectionRequestTest.kt
@@ -16,22 +16,22 @@ import tech.relaycorp.relaynet.wrappers.x509.CertificateException
 class CargoCollectionRequestTest {
     @Test
     fun `CDA should be accessible from instance`() {
-        val ccr = CargoCollectionRequest(CDACertPath.PUBLIC_GW)
+        val ccr = CargoCollectionRequest(CDACertPath.INTERNET_GW)
 
-        assertEquals(CDACertPath.PUBLIC_GW, ccr.cargoDeliveryAuthorization)
+        assertEquals(CDACertPath.INTERNET_GW, ccr.cargoDeliveryAuthorization)
     }
 
     @Nested
     inner class Serialize {
         @Test
         fun `Cargo Delivery Authorization should be included DER-encoded`() {
-            val ccr = CargoCollectionRequest(CDACertPath.PUBLIC_GW)
+            val ccr = CargoCollectionRequest(CDACertPath.INTERNET_GW)
 
             val serialization = ccr.serializePlaintext()
 
             val sequence = ASN1Utils.deserializeHeterogeneousSequence(serialization)
             val cdaASN1 = ASN1Utils.getOctetString(sequence.first())
-            assertEquals(CDACertPath.PUBLIC_GW, Certificate.deserialize(cdaASN1.octets))
+            assertEquals(CDACertPath.INTERNET_GW, Certificate.deserialize(cdaASN1.octets))
         }
     }
 
@@ -72,12 +72,12 @@ class CargoCollectionRequestTest {
 
         @Test
         fun `Valid values should be accepted`() {
-            val ccr = CargoCollectionRequest(CDACertPath.PUBLIC_GW)
+            val ccr = CargoCollectionRequest(CDACertPath.INTERNET_GW)
             val serialization = ccr.serializePlaintext()
 
             val ccrDeserialized = CargoCollectionRequest.deserialize(serialization)
 
-            assertEquals(CDACertPath.PUBLIC_GW, ccrDeserialized.cargoDeliveryAuthorization)
+            assertEquals(CDACertPath.INTERNET_GW, ccrDeserialized.cargoDeliveryAuthorization)
         }
     }
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/payloads/CargoMessageSetTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/payloads/CargoMessageSetTest.kt
@@ -146,7 +146,7 @@ internal class CargoMessageSetTest {
                     .serialize()
             val cargoMessageSet = CargoMessageSet(arrayOf(parcelSerialized, pcaSerialized))
 
-            val cargoMessages = cargoMessageSet.classifyMessages().asSequence().toList()
+            val cargoMessages = cargoMessageSet.classifyMessages().toList()
 
             assertEquals(2, cargoMessages.size)
             assertEquals(CargoMessage.Type.PARCEL, cargoMessages[0].type)

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/payloads/CargoMessageTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/payloads/CargoMessageTest.kt
@@ -11,15 +11,14 @@ import tech.relaycorp.relaynet.pki.CertificationPath
 import tech.relaycorp.relaynet.utils.ID_CERTIFICATE
 import tech.relaycorp.relaynet.utils.ID_KEY_PAIR
 import tech.relaycorp.relaynet.utils.PDACertPath
+import tech.relaycorp.relaynet.utils.RAMFStubs
 
 class CargoMessageTest {
     @Nested
     inner class Constructor {
-        private val recipientEndpointAddress = "https://foo.relaycorp.tech"
-
         @Test
         fun `Parcels should be correctly classified as such`() {
-            val parcel = Parcel(recipientEndpointAddress, "".toByteArray(), ID_CERTIFICATE)
+            val parcel = Parcel(RAMFStubs.recipient, "".toByteArray(), ID_CERTIFICATE)
             val parcelSerialized = parcel.serialize(ID_KEY_PAIR.private)
 
             val cargoMessage = CargoMessage(parcelSerialized)
@@ -29,7 +28,7 @@ class CargoMessageTest {
 
         @Test
         fun `PCAs should be correctly classified as such`() {
-            val pca = ParcelCollectionAck("0deadbeef", recipientEndpointAddress, "parcel-id")
+            val pca = ParcelCollectionAck("0deadbeef", RAMFStubs.recipientId, "parcel-id")
             val pcaSerialized = pca.serialize()
 
             val cargoMessage = CargoMessage(pcaSerialized)

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/payloads/CargoMessageTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/payloads/CargoMessageTest.kt
@@ -56,7 +56,7 @@ class CargoMessageTest {
 
         @Test
         fun `Invalid messages should not be assigned a type`() {
-            val cargoMessage = CargoMessage("RelaynetyP0".toByteArray())
+            val cargoMessage = CargoMessage("AwaloP0".toByteArray())
 
             assertNull(cargoMessage.type)
         }

--- a/src/test/kotlin/tech/relaycorp/relaynet/nodes/NodeManagerTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/nodes/NodeManagerTest.kt
@@ -35,9 +35,9 @@ import tech.relaycorp.relaynet.wrappers.cms.SessionEnvelopedData
 class NodeManagerTest {
     private val payload = StubEncryptedPayload("the payload")
 
-    private val ownPrivateAddress = PDACertPath.PRIVATE_ENDPOINT.subjectId
+    private val nodeId = PDACertPath.PRIVATE_ENDPOINT.subjectId
 
-    private val peerPrivateAddress = PDACertPath.PDA.subjectId
+    private val peerId = PDACertPath.PDA.subjectId
     private val peerSessionKeyPair = SessionKeyPair.generate()
     private val peerSessionKey = peerSessionKeyPair.sessionKey
     private val peerSessionPrivateKey = peerSessionKeyPair.privateKey
@@ -58,11 +58,11 @@ class NodeManagerTest {
         fun `Key should not be bound to any peer by default`() = runTest {
             val manager = StubNodeManager(privateKeyStore, publicKeyStore)
 
-            val (sessionKey, privateKey) = manager.generateSessionKeyPair(ownPrivateAddress)
+            val (sessionKey, privateKey) = manager.generateSessionKeyPair(nodeId)
 
             val sessionKeyForDifferentPeer = privateKeyStore.retrieveSessionKey(
                 sessionKey.keyId,
-                ownPrivateAddress,
+                nodeId,
                 "insert any address here"
             )
             assertNotNull(sessionKeyForDifferentPeer)
@@ -77,15 +77,15 @@ class NodeManagerTest {
             val manager = StubNodeManager(privateKeyStore, publicKeyStore)
 
             val (sessionKey, privateKey) = manager.generateSessionKeyPair(
-                ownPrivateAddress,
-                peerPrivateAddress
+                nodeId,
+                peerId
             )
 
             // We should get the key with the right peer
             val sessionKeyForDifferentPeer = privateKeyStore.retrieveSessionKey(
                 sessionKey.keyId,
-                ownPrivateAddress,
-                peerPrivateAddress,
+                nodeId,
+                peerId,
             )
             assertEquals(
                 privateKey.encoded.asList(),
@@ -95,8 +95,8 @@ class NodeManagerTest {
             assertThrows<MissingKeyException> {
                 privateKeyStore.retrieveSessionKey(
                     sessionKey.keyId,
-                    ownPrivateAddress,
-                    "not $peerPrivateAddress",
+                    nodeId,
+                    "not $peerId",
                 )
             }
         }
@@ -105,7 +105,7 @@ class NodeManagerTest {
         fun `Key should use P-256 by default`() = runTest {
             val manager = StubNodeManager(privateKeyStore, publicKeyStore)
 
-            val (sessionKey) = manager.generateSessionKeyPair(peerPrivateAddress)
+            val (sessionKey) = manager.generateSessionKeyPair(peerId)
 
             assertEquals(
                 "P-256",
@@ -118,7 +118,7 @@ class NodeManagerTest {
         fun explicitCurveName(curve: ECDHCurve) = runTest {
             val manager = StubNodeManager(privateKeyStore, publicKeyStore, NodeCryptoOptions(curve))
 
-            val (sessionKey) = manager.generateSessionKeyPair(peerPrivateAddress)
+            val (sessionKey) = manager.generateSessionKeyPair(peerId)
 
             val curveName = ECDH_CURVE_MAP[curve]
             assertEquals(
@@ -132,7 +132,7 @@ class NodeManagerTest {
     inner class WrapMessagePayload {
         @BeforeEach
         fun registerPeerSessionKey() = runTest {
-            publicKeyStore.save(peerSessionKey, peerPrivateAddress)
+            publicKeyStore.save(peerSessionKey, peerId)
         }
 
         @Test
@@ -141,10 +141,10 @@ class NodeManagerTest {
             publicKeyStore.clear()
 
             val exception = assertThrows<MissingKeyException> {
-                manager.wrapMessagePayload(payload, peerPrivateAddress, ownPrivateAddress)
+                manager.wrapMessagePayload(payload, peerId, nodeId)
             }
 
-            assertEquals("There is no session key for $peerPrivateAddress", exception.message)
+            assertEquals("There is no session key for $peerId", exception.message)
         }
 
         @Test
@@ -152,7 +152,7 @@ class NodeManagerTest {
             val manager = StubNodeManager(privateKeyStore, publicKeyStore)
 
             val ciphertext =
-                manager.wrapMessagePayload(payload, peerPrivateAddress, ownPrivateAddress)
+                manager.wrapMessagePayload(payload, peerId, nodeId)
 
             val envelopedData = EnvelopedData.deserialize(ciphertext)
             assertTrue(envelopedData is SessionEnvelopedData)
@@ -172,15 +172,15 @@ class NodeManagerTest {
             assertEquals(0, privateKeyStore.sessionKeys.size)
 
             val ciphertext =
-                manager.wrapMessagePayload(payload, peerPrivateAddress, ownPrivateAddress)
+                manager.wrapMessagePayload(payload, peerId, nodeId)
 
             val envelopedData = EnvelopedData.deserialize(ciphertext)
             assertTrue(envelopedData is SessionEnvelopedData)
             assertNotNull(
                 privateKeyStore.retrieveSessionKey(
                     envelopedData.getOriginatorKey().keyId,
-                    ownPrivateAddress,
-                    peerPrivateAddress,
+                    nodeId,
+                    peerId,
                 )
             )
         }
@@ -190,7 +190,7 @@ class NodeManagerTest {
             val manager = StubNodeManager(privateKeyStore, publicKeyStore)
 
             val ciphertext =
-                manager.wrapMessagePayload(payload, peerPrivateAddress, ownPrivateAddress)
+                manager.wrapMessagePayload(payload, peerId, nodeId)
 
             val envelopedData = EnvelopedData.deserialize(ciphertext)
             assertTrue(envelopedData is SessionEnvelopedData)
@@ -198,8 +198,8 @@ class NodeManagerTest {
             assertThrows<MissingKeyException> {
                 privateKeyStore.retrieveSessionKey(
                     keyId,
-                    ownPrivateAddress,
-                    "not $peerPrivateAddress",
+                    nodeId,
+                    "not $peerId",
                 )
             }
         }
@@ -209,7 +209,7 @@ class NodeManagerTest {
             val manager = StubNodeManager(privateKeyStore, publicKeyStore)
 
             val ciphertext =
-                manager.wrapMessagePayload(payload, peerPrivateAddress, ownPrivateAddress)
+                manager.wrapMessagePayload(payload, peerId, nodeId)
 
             val envelopedData = EnvelopedData.deserialize(ciphertext)
             assertEquals(
@@ -228,7 +228,7 @@ class NodeManagerTest {
             )
 
             val ciphertext =
-                manager.wrapMessagePayload(payload, peerPrivateAddress, ownPrivateAddress)
+                manager.wrapMessagePayload(payload, peerId, nodeId)
 
             val envelopedData = EnvelopedData.deserialize(ciphertext)
             assertEquals(
@@ -242,7 +242,7 @@ class NodeManagerTest {
             val manager = StubNodeManager(privateKeyStore, publicKeyStore)
 
             val ciphertext =
-                manager.wrapMessagePayload(payload, peerPrivateAddress, ownPrivateAddress)
+                manager.wrapMessagePayload(payload, peerId, nodeId)
 
             val envelopedData = EnvelopedData.deserialize(ciphertext)
             val recipientInfo = envelopedData.bcEnvelopedData.recipientInfos.first() as
@@ -265,7 +265,7 @@ class NodeManagerTest {
             )
 
             val ciphertext =
-                manager.wrapMessagePayload(payload, peerPrivateAddress, ownPrivateAddress)
+                manager.wrapMessagePayload(payload, peerId, nodeId)
 
             val envelopedData = EnvelopedData.deserialize(ciphertext)
             val recipientInfo = envelopedData.bcEnvelopedData.recipientInfos.first() as
@@ -299,8 +299,8 @@ class NodeManagerTest {
             privateKeyStore.saveSessionKey(
                 ownSessionKeyPair.privateKey,
                 ownSessionKeyPair.sessionKey.keyId,
-                ownPrivateAddress,
-                peerPrivateAddress,
+                nodeId,
+                peerId,
             )
         }
 
@@ -328,8 +328,8 @@ class NodeManagerTest {
 
             manager.unwrapMessagePayload(message)
 
-            assertEquals(peerSessionKey, publicKeyStore.retrieve(peerPrivateAddress))
-            val storedKey = publicKeyStore.keys[peerPrivateAddress]!!
+            assertEquals(peerSessionKey, publicKeyStore.retrieve(peerId))
+            val storedKey = publicKeyStore.keys[peerId]!!
             assertEquals(message.creationDate.toEpochSecond(), storedKey.creationTimestamp)
         }
     }

--- a/src/test/kotlin/tech/relaycorp/relaynet/nodes/NodeManagerTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/nodes/NodeManagerTest.kt
@@ -20,6 +20,7 @@ import tech.relaycorp.relaynet.HashingAlgorithm
 import tech.relaycorp.relaynet.SessionKeyPair
 import tech.relaycorp.relaynet.SymmetricCipher
 import tech.relaycorp.relaynet.keystores.MissingKeyException
+import tech.relaycorp.relaynet.messages.Recipient
 import tech.relaycorp.relaynet.utils.MockPrivateKeyStore
 import tech.relaycorp.relaynet.utils.MockSessionPublicKeyStore
 import tech.relaycorp.relaynet.utils.PDACertPath
@@ -34,9 +35,9 @@ import tech.relaycorp.relaynet.wrappers.cms.SessionEnvelopedData
 class NodeManagerTest {
     private val payload = StubEncryptedPayload("the payload")
 
-    private val ownPrivateAddress = PDACertPath.PRIVATE_ENDPOINT.subjectPrivateAddress
+    private val ownPrivateAddress = PDACertPath.PRIVATE_ENDPOINT.subjectId
 
-    private val peerPrivateAddress = PDACertPath.PDA.subjectPrivateAddress
+    private val peerPrivateAddress = PDACertPath.PDA.subjectId
     private val peerSessionKeyPair = SessionKeyPair.generate()
     private val peerSessionKey = peerSessionKeyPair.sessionKey
     private val peerSessionPrivateKey = peerSessionKeyPair.privateKey
@@ -288,7 +289,7 @@ class NodeManagerTest {
             peerSessionKeyPair,
         )
         private val message = StubEncryptedRAMFMessage(
-            PDACertPath.PRIVATE_ENDPOINT.subjectPrivateAddress,
+            Recipient(PDACertPath.PRIVATE_ENDPOINT.subjectId),
             envelopedData.serialize(),
             PDACertPath.PDA
         )

--- a/src/test/kotlin/tech/relaycorp/relaynet/ramf/EncryptedRAMFMessageTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/ramf/EncryptedRAMFMessageTest.kt
@@ -20,7 +20,7 @@ import tech.relaycorp.relaynet.wrappers.generateECDHKeyPair
 
 @ExperimentalCoroutinesApi
 internal class EncryptedRAMFMessageTest {
-    private val senderPrivateAddress = PDACertPath.PDA.subjectId
+    private val senderId = PDACertPath.PDA.subjectId
     private val senderSessionKeyPair = SessionKeyPair.generate()
 
     private val recipient = Recipient(PDACertPath.PRIVATE_ENDPOINT.subjectId)
@@ -38,7 +38,7 @@ internal class EncryptedRAMFMessageTest {
                 recipientSessionKeyPair.privateKey,
                 recipientSessionKeyPair.sessionKey.keyId,
                 recipient.id,
-                senderPrivateAddress,
+                senderId,
             )
         }
 

--- a/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessageTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessageTest.kt
@@ -299,13 +299,13 @@ class RAMFMessageTest {
         )
 
         val certificationPath =
-            message.getSenderCertificationPath(setOf(PDACertPath.PUBLIC_GW))
+            message.getSenderCertificationPath(setOf(PDACertPath.INTERNET_GW))
 
         assertEquals(
             listOf(
                 PDACertPath.PRIVATE_ENDPOINT,
                 PDACertPath.PRIVATE_GW,
-                PDACertPath.PUBLIC_GW
+                PDACertPath.INTERNET_GW
             ),
             certificationPath.asList()
         )
@@ -436,7 +436,7 @@ class RAMFMessageTest {
                 )
 
                 val exception = assertThrows<InvalidMessageException> {
-                    message.validate(setOf(PDACertPath.PUBLIC_GW))
+                    message.validate(setOf(PDACertPath.INTERNET_GW))
                 }
 
                 assertEquals("Sender is not trusted", exception.message)
@@ -455,7 +455,7 @@ class RAMFMessageTest {
                     )
                 )
 
-                message.validate(setOf(PDACertPath.PUBLIC_GW))
+                message.validate(setOf(PDACertPath.INTERNET_GW))
             }
 
             @Test
@@ -473,7 +473,7 @@ class RAMFMessageTest {
                 )
 
                 val exception = assertThrows<InvalidMessageException> {
-                    message.validate(setOf(PDACertPath.PUBLIC_GW))
+                    message.validate(setOf(PDACertPath.INTERNET_GW))
                 }
 
                 assertEquals("Sender is authorized by the wrong recipient", exception.message)

--- a/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessageTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessageTest.kt
@@ -5,15 +5,16 @@ import java.time.ZonedDateTime
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertThrows
 import tech.relaycorp.relaynet.HashingAlgorithm
 import tech.relaycorp.relaynet.messages.InvalidMessageException
+import tech.relaycorp.relaynet.messages.Recipient
 import tech.relaycorp.relaynet.utils.KeyPairSet
 import tech.relaycorp.relaynet.utils.PDACertPath
+import tech.relaycorp.relaynet.utils.RAMFStubs
 import tech.relaycorp.relaynet.utils.StubEncryptedRAMFMessage
 import tech.relaycorp.relaynet.utils.assertDateIsAlmostNow
 import tech.relaycorp.relaynet.utils.issueStubCertificate
@@ -24,7 +25,7 @@ import tech.relaycorp.relaynet.wrappers.x509.Certificate
 import tech.relaycorp.relaynet.wrappers.x509.CertificateException
 
 class RAMFMessageTest {
-    private val recipientAddress = PDACertPath.PRIVATE_ENDPOINT.subjectPrivateAddress
+    private val recipient = RAMFStubs.recipient
     private val messageId = "message-id"
     private val creationDateUtc: ZonedDateTime = ZonedDateTime.now(ZoneId.of("UTC"))
     private val ttl = 1
@@ -36,28 +37,11 @@ class RAMFMessageTest {
     @Nested
     inner class Constructor {
         @Test
-        fun `Recipient address should not span more than 1024 octets`() {
-            val longRecipientAddress = "a".repeat(1025)
-            val exception = assertThrows<RAMFException> {
-                StubEncryptedRAMFMessage(
-                    longRecipientAddress,
-                    payload,
-                    senderCertificate
-                )
-            }
-
-            assertEquals(
-                "Recipient address cannot span more than 1024 octets (got 1025)",
-                exception.message
-            )
-        }
-
-        @Test
         fun `Message id should not span more than 64 octets`() {
             val longMessageId = "a".repeat(65)
             val exception = assertThrows<RAMFException> {
                 StubEncryptedRAMFMessage(
-                    recipientAddress,
+                    recipient,
                     payload,
                     senderCertificate,
                     longMessageId
@@ -73,7 +57,7 @@ class RAMFMessageTest {
         @Test
         fun `Message id should be honored if set`() {
             val message = StubEncryptedRAMFMessage(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate,
                 messageId
@@ -85,12 +69,12 @@ class RAMFMessageTest {
         @Test
         fun `Message id should default to random UUID4 if unset`() {
             val message1 = StubEncryptedRAMFMessage(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate
             )
             val message2 = StubEncryptedRAMFMessage(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate
             )
@@ -103,7 +87,7 @@ class RAMFMessageTest {
         @Test
         fun `Creation time should be honored if set`() {
             val message = StubEncryptedRAMFMessage(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate,
                 creationDate = creationDateUtc
@@ -115,7 +99,7 @@ class RAMFMessageTest {
         @Test
         fun `Creation date should default to current UTC time if unset`() {
             val message = StubEncryptedRAMFMessage(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate
             )
@@ -129,7 +113,7 @@ class RAMFMessageTest {
             val negativeTtl = -1
             val exception = assertThrows<RAMFException> {
                 StubEncryptedRAMFMessage(
-                    recipientAddress,
+                    recipient,
                     payload,
                     senderCertificate,
                     ttl = negativeTtl
@@ -145,7 +129,7 @@ class RAMFMessageTest {
             val longTtl = secondsIn180Days + 1
             val exception = assertThrows<RAMFException> {
                 StubEncryptedRAMFMessage(
-                    recipientAddress,
+                    recipient,
                     payload,
                     senderCertificate,
                     ttl = longTtl
@@ -161,7 +145,7 @@ class RAMFMessageTest {
         @Test
         fun `TTL should be honored if set`() {
             val message = StubEncryptedRAMFMessage(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate,
                 ttl = ttl
@@ -173,7 +157,7 @@ class RAMFMessageTest {
         @Test
         fun `TTL should default to 5 minutes if unset`() {
             val message = StubEncryptedRAMFMessage(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate
             )
@@ -188,7 +172,7 @@ class RAMFMessageTest {
             val longPayload = "a".repeat(longPayloadLength).toByteArray()
             val exception = assertThrows<RAMFException> {
                 StubEncryptedRAMFMessage(
-                    recipientAddress,
+                    recipient,
                     longPayload,
                     senderCertificate
                 )
@@ -205,7 +189,7 @@ class RAMFMessageTest {
         fun `Sender certificate chain should be honored if set`() {
             val chain = setOf(senderCertificate)
             val message = StubEncryptedRAMFMessage(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate,
                 senderCertificateChain = chain
@@ -217,7 +201,7 @@ class RAMFMessageTest {
         @Test
         fun `Sender certificate chain should default to an empty set if unset`() {
             val message = StubEncryptedRAMFMessage(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate
             )
@@ -235,7 +219,7 @@ class RAMFMessageTest {
                 senderKeyPair.private
             )
             val message = StubEncryptedRAMFMessage(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate,
                 messageId,
@@ -249,7 +233,7 @@ class RAMFMessageTest {
 
             val messageDeserialized = StubEncryptedRAMFMessage.deserialize(serialization)
             // TODO: Implement RAMFMessage.equals() and use it here
-            assertEquals(message.recipientAddress, messageDeserialized.recipientAddress)
+            assertEquals(message.recipient, messageDeserialized.recipient)
             assertEquals(message.id, messageDeserialized.id)
             assertEquals(
                 message.creationDate.withNano(0).withZoneSameLocal(ZoneId.of("UTC")),
@@ -267,7 +251,7 @@ class RAMFMessageTest {
         @Nested
         inner class Hashing {
             private val stubMessage = StubEncryptedRAMFMessage(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate
             )
@@ -308,7 +292,7 @@ class RAMFMessageTest {
     @Test
     fun `getSenderCertificationPath should return certification path`() {
         val message = StubEncryptedRAMFMessage(
-            recipientAddress,
+            recipient,
             payload,
             PDACertPath.PRIVATE_ENDPOINT,
             senderCertificateChain = setOf(PDACertPath.PRIVATE_GW)
@@ -335,13 +319,13 @@ class RAMFMessageTest {
             fun `Creation date in the future should be refused`() {
                 val futureDate = ZonedDateTime.now().plusSeconds(2)
                 val message = StubEncryptedRAMFMessage(
-                    recipientAddress,
+                    recipient,
                     payload,
                     senderCertificate,
                     creationDate = futureDate
                 )
 
-                val exception = assertThrows<RAMFException> { message.validate(null) }
+                val exception = assertThrows<RAMFException> { message.validate() }
 
                 assertEquals("Creation date is in the future", exception.message)
             }
@@ -351,20 +335,20 @@ class RAMFMessageTest {
                 val creationDate = senderCertificate.certificateHolder.notBefore.toInstant()
                     .atZone(ZoneId.systemDefault())
                 val message = StubEncryptedRAMFMessage(
-                    recipientAddress,
+                    recipient,
                     payload,
                     senderCertificate,
                     creationDate = creationDate
                 )
 
-                message.validate(null)
+                message.validate()
             }
 
             @Test
             fun `Creation date equal to the current date should be accepted`() {
-                val message = StubEncryptedRAMFMessage(recipientAddress, payload, senderCertificate)
+                val message = StubEncryptedRAMFMessage(recipient, payload, senderCertificate)
 
-                message.validate(null)
+                message.validate()
             }
 
             @Test
@@ -378,14 +362,14 @@ class RAMFMessageTest {
                     validityStartDate = now.minusMinutes(1)
                 )
                 val message = StubEncryptedRAMFMessage(
-                    recipientAddress,
+                    recipient,
                     payload,
                     certificate,
                     creationDate = now.minusNanos(500_000),
                     ttl = 1
                 )
 
-                message.validate(null)
+                message.validate()
             }
 
             @Test
@@ -393,14 +377,14 @@ class RAMFMessageTest {
                 val creationDate = senderCertificate.certificateHolder.notBefore.toInstant()
                     .atZone(ZoneId.systemDefault())
                 val message = StubEncryptedRAMFMessage(
-                    recipientAddress,
+                    recipient,
                     payload,
                     senderCertificate,
                     creationDate = creationDate,
                     ttl = 0
                 )
 
-                val exception = assertThrows<RAMFException> { message.validate(null) }
+                val exception = assertThrows<RAMFException> { message.validate() }
 
                 assertEquals("Message already expired", exception.message)
             }
@@ -416,116 +400,16 @@ class RAMFMessageTest {
                     validityStartDate = now.minusSeconds(2)
                 )
                 val message = StubEncryptedRAMFMessage(
-                    recipientAddress,
+                    recipient,
                     payload,
                     expiredCertificate,
                     creationDate = now
                 )
 
-                val exception = assertThrows<RAMFException> { message.validate(null) }
+                val exception = assertThrows<RAMFException> { message.validate() }
 
                 assertTrue(exception.cause is CertificateException)
                 assertEquals("Invalid sender certificate", exception.message)
-            }
-        }
-
-        @Nested
-        inner class RecipientAddress {
-            private val privateAddress = "0deadbeef"
-            private val publicAddress = "https://example.com"
-
-            @Test
-            fun `Public address should be allowed if no specific type is required`() {
-                val message = StubEncryptedRAMFMessage(
-                    publicAddress,
-                    payload,
-                    senderCertificate,
-                    messageId
-                )
-
-                message.validate(null)
-            }
-
-            @Test
-            fun `Private address should be allowed if no specific type is required`() {
-                val message = StubEncryptedRAMFMessage(
-                    privateAddress,
-                    payload,
-                    senderCertificate,
-                    messageId
-                )
-
-                message.validate(null)
-            }
-
-            @Test
-            fun `Invalid addresses should be refused`() {
-                val message = StubEncryptedRAMFMessage(
-                    "this is an invalid private address",
-                    payload,
-                    senderCertificate,
-                    messageId
-                )
-
-                val exception = assertThrows<RAMFException> { message.validate(null) }
-
-                assertEquals("Recipient address is an invalid private address", exception.message)
-            }
-
-            @Test
-            fun `Private address should be refused if a public one is required`() {
-                val message = StubEncryptedRAMFMessage(
-                    privateAddress,
-                    payload,
-                    senderCertificate,
-                    messageId
-                )
-
-                val exception = assertThrows<InvalidMessageException> {
-                    message.validate(RecipientAddressType.PUBLIC)
-                }
-
-                assertEquals("Invalid recipient address type", exception.message)
-            }
-
-            @Test
-            fun `Public address should be refused if a private one is required`() {
-                val message = StubEncryptedRAMFMessage(
-                    publicAddress,
-                    payload,
-                    senderCertificate,
-                    messageId
-                )
-
-                val exception = assertThrows<InvalidMessageException> {
-                    message.validate(RecipientAddressType.PRIVATE)
-                }
-
-                assertEquals("Invalid recipient address type", exception.message)
-            }
-
-            @Test
-            fun `Private address should be allowed if a private one is required`() {
-                val message = StubEncryptedRAMFMessage(
-                    privateAddress,
-                    payload,
-                    senderCertificate,
-                    messageId
-                )
-
-                message.validate(RecipientAddressType.PRIVATE)
-            }
-
-            @Test
-            fun `Public address should be allowed if a public one is required`() {
-                val message = StubEncryptedRAMFMessage(
-                    publicAddress,
-                    payload,
-                    senderCertificate,
-                    messageId
-                )
-
-                message.validate(RecipientAddressType.PUBLIC)
             }
         }
 
@@ -546,13 +430,13 @@ class RAMFMessageTest {
                     untrustedRecipientCert
                 )
                 val message = StubEncryptedRAMFMessage(
-                    untrustedRecipientCert.subjectPrivateAddress,
+                    Recipient(untrustedRecipientCert.subjectId),
                     payload,
                     untrustedSenderCert
                 )
 
                 val exception = assertThrows<InvalidMessageException> {
-                    message.validate(null, setOf(PDACertPath.PUBLIC_GW))
+                    message.validate(setOf(PDACertPath.PUBLIC_GW))
                 }
 
                 assertEquals("Sender is not trusted", exception.message)
@@ -560,9 +444,9 @@ class RAMFMessageTest {
             }
 
             @Test
-            fun `Message should be accepted if recipient is private and sender is trusted`() {
+            fun `Message should be accepted if sender is trusted`() {
                 val message = StubEncryptedRAMFMessage(
-                    PDACertPath.PRIVATE_ENDPOINT.subjectPrivateAddress,
+                    Recipient(PDACertPath.PRIVATE_ENDPOINT.subjectId),
                     payload,
                     PDACertPath.PDA,
                     senderCertificateChain = setOf(
@@ -571,40 +455,25 @@ class RAMFMessageTest {
                     )
                 )
 
-                message.validate(null, setOf(PDACertPath.PUBLIC_GW))
+                message.validate(setOf(PDACertPath.PUBLIC_GW))
             }
 
             @Test
-            fun `Message should be accepted if recipient is public and sender is trusted`() {
-                val message = StubEncryptedRAMFMessage(
-                    "https://endpoint.example.com",
-                    payload,
-                    PDACertPath.PDA,
-                    senderCertificateChain = setOf(
-                        PDACertPath.PRIVATE_GW,
-                        PDACertPath.PRIVATE_ENDPOINT
-                    )
-                )
-
-                message.validate(null, setOf(PDACertPath.PUBLIC_GW))
-            }
-
-            @Test
-            fun `Message should be refused if private recipient doesn't match sender issuer`() {
+            fun `Message should be refused if recipient doesn't match sender issuer`() {
                 val anotherRecipientKeyPair = generateRSAKeyPair()
                 val anotherRecipientCert = issueStubCertificate(
                     anotherRecipientKeyPair.public,
                     anotherRecipientKeyPair.private
                 )
                 val message = StubEncryptedRAMFMessage(
-                    anotherRecipientCert.subjectPrivateAddress,
+                    Recipient(anotherRecipientCert.subjectId),
                     payload,
                     PDACertPath.PRIVATE_ENDPOINT,
                     senderCertificateChain = setOf(PDACertPath.PRIVATE_GW)
                 )
 
                 val exception = assertThrows<InvalidMessageException> {
-                    message.validate(null, setOf(PDACertPath.PUBLIC_GW))
+                    message.validate(setOf(PDACertPath.PUBLIC_GW))
                 }
 
                 assertEquals("Sender is authorized by the wrong recipient", exception.message)
@@ -618,47 +487,20 @@ class RAMFMessageTest {
                     untrustedSenderKeyPair.private
                 )
                 val message = StubEncryptedRAMFMessage(
-                    PDACertPath.PRIVATE_ENDPOINT.subjectPrivateAddress,
+                    Recipient(PDACertPath.PRIVATE_ENDPOINT.subjectId),
                     payload,
                     untrustedSenderCert
                 )
 
-                message.validate(null)
+                message.validate()
             }
-        }
-    }
-
-    @Nested
-    inner class IsRecipientAddressPrivate {
-        @Test
-        fun `Private addresses should be reported as such`() {
-            val message = StubEncryptedRAMFMessage(
-                "0deadbeef",
-                payload,
-                senderCertificate,
-                messageId
-            )
-
-            assertTrue { message.isRecipientAddressPrivate }
-        }
-
-        @Test
-        fun `Public addresses should be reported as such`() {
-            val message = StubEncryptedRAMFMessage(
-                "https://example.com",
-                payload,
-                senderCertificate,
-                messageId
-            )
-
-            assertFalse { message.isRecipientAddressPrivate }
         }
     }
 
     @Test
     fun `expiryDate should be calculated from the creationDate and ttl`() {
         val message = StubEncryptedRAMFMessage(
-            recipientAddress,
+            recipient,
             payload,
             senderCertificate,
             creationDate = creationDateUtc,

--- a/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFSpecializationTestCase.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFSpecializationTestCase.kt
@@ -76,8 +76,8 @@ internal abstract class RAMFSpecializationTestCase<M : RAMFMessage<*>>(
         fun `Serializer should be configured to use specified message type and version`() {
             val messageSerialized = simpleMessage.serialize(keyPair.private)
 
-            assertEquals(expectedConcreteMessageType, messageSerialized[8])
-            assertEquals(expectedConcreteMessageVersion, messageSerialized[9])
+            assertEquals(expectedConcreteMessageType, messageSerialized[5])
+            assertEquals(expectedConcreteMessageVersion, messageSerialized[6])
         }
 
         @Test

--- a/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFSpecializationTestCase.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFSpecializationTestCase.kt
@@ -4,12 +4,14 @@ import java.time.ZonedDateTime
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import tech.relaycorp.relaynet.messages.Recipient
 import tech.relaycorp.relaynet.utils.ID_CERTIFICATE
+import tech.relaycorp.relaynet.utils.RAMFStubs
 import tech.relaycorp.relaynet.utils.issueStubCertificate
 import tech.relaycorp.relaynet.wrappers.generateRSAKeyPair
 import tech.relaycorp.relaynet.wrappers.x509.Certificate
 
-typealias MinimalRAMFMessageConstructor<M> = (String, ByteArray, Certificate) -> M
+typealias MinimalRAMFMessageConstructor<M> = (Recipient, ByteArray, Certificate) -> M
 
 internal abstract class RAMFSpecializationTestCase<M : RAMFMessage<*>>(
     private val messageConstructor: RAMFMessageConstructor<M>,
@@ -18,15 +20,15 @@ internal abstract class RAMFSpecializationTestCase<M : RAMFMessage<*>>(
     private val expectedConcreteMessageVersion: Byte,
     private val companion: RAMFMessageCompanion<M>
 ) {
-    val simpleMessage = requiredParamsConstructor(recipientAddress, payload, senderCertificate)
+    val simpleMessage = requiredParamsConstructor(recipient, payload, senderCertificate)
 
     @Nested
     inner class Constructor {
         @Test
         fun `Required arguments should be honored`() {
-            val message = requiredParamsConstructor(recipientAddress, payload, senderCertificate)
+            val message = requiredParamsConstructor(recipient, payload, senderCertificate)
 
-            assertEquals(recipientAddress, message.recipientAddress)
+            assertEquals(recipient, message.recipient)
             assertEquals(payload.asList(), message.payload.asList())
             assertEquals(senderCertificate, message.senderCertificate)
         }
@@ -39,7 +41,7 @@ internal abstract class RAMFSpecializationTestCase<M : RAMFMessage<*>>(
             val date = ZonedDateTime.now()
 
             val message = messageConstructor(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate,
                 id,
@@ -59,7 +61,7 @@ internal abstract class RAMFSpecializationTestCase<M : RAMFMessage<*>>(
     inner class Serialization {
         @Test
         fun `Recipient address should be honored`() {
-            assertEquals(recipientAddress, simpleMessage.recipientAddress)
+            assertEquals(recipient, simpleMessage.recipient)
         }
 
         @Test
@@ -84,7 +86,7 @@ internal abstract class RAMFSpecializationTestCase<M : RAMFMessage<*>>(
         fun `Message id should be honored if set`() {
             val messageId = "the-id"
             val message = messageConstructor(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate,
                 messageId,
@@ -101,7 +103,7 @@ internal abstract class RAMFSpecializationTestCase<M : RAMFMessage<*>>(
             val creationDate = ZonedDateTime.now().minusMinutes(10)
             val message =
                 messageConstructor(
-                    recipientAddress,
+                    recipient,
                     payload,
                     senderCertificate,
                     null,
@@ -118,7 +120,7 @@ internal abstract class RAMFSpecializationTestCase<M : RAMFMessage<*>>(
             val ttl = 42
             val message =
                 messageConstructor(
-                    recipientAddress,
+                    recipient,
                     payload,
                     senderCertificate,
                     null,
@@ -136,7 +138,7 @@ internal abstract class RAMFSpecializationTestCase<M : RAMFMessage<*>>(
                 issueStubCertificate(keyPair.public, keyPair.private)
             )
             val message = messageConstructor(
-                recipientAddress,
+                recipient,
                 payload,
                 senderCertificate,
                 null,
@@ -169,7 +171,7 @@ internal abstract class RAMFSpecializationTestCase<M : RAMFMessage<*>>(
     }
 
     companion object {
-        private const val recipientAddress = "0deadbeef"
+        private val recipient = Recipient(RAMFStubs.recipientId)
         private val payload = "Payload".toByteArray()
         private val keyPair = generateRSAKeyPair()
         private val senderCertificate = issueStubCertificate(keyPair.public, keyPair.private)

--- a/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFUtils.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFUtils.kt
@@ -1,5 +1,5 @@
 package tech.relaycorp.relaynet.ramf
 
 fun skipFormatSignature(ramfMessage: ByteArray): ByteArray {
-    return ramfMessage.copyOfRange(10, ramfMessage.lastIndex + 1)
+    return ramfMessage.copyOfRange(7, ramfMessage.lastIndex + 1)
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/utils/CDACertPath.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/utils/CDACertPath.kt
@@ -14,13 +14,13 @@ object CDACertPath {
 
     val PRIVATE_GW = issueGatewayCertificate(
         KeyPairSet.PRIVATE_GW.public,
-        KeyPairSet.PUBLIC_GW.private,
+        KeyPairSet.INTERNET_GW.private,
         tomorrow,
         validityStartDate = twoSecondsAgo
     )
-    val PUBLIC_GW = issueDeliveryAuthorization(
-        KeyPairSet.PUBLIC_GW.public,
-        KeyPairSet.PUBLIC_GW.private,
+    val INTERNET_GW = issueDeliveryAuthorization(
+        KeyPairSet.INTERNET_GW.public,
+        KeyPairSet.INTERNET_GW.private,
         tomorrow,
         PRIVATE_GW,
         validityStartDate = twoSecondsAgo

--- a/src/test/kotlin/tech/relaycorp/relaynet/utils/KeyPairSet.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/utils/KeyPairSet.kt
@@ -3,7 +3,7 @@ package tech.relaycorp.relaynet.utils
 import tech.relaycorp.relaynet.wrappers.generateRSAKeyPair
 
 object KeyPairSet {
-    val PUBLIC_GW = generateRSAKeyPair()
+    val INTERNET_GW = generateRSAKeyPair()
     val PRIVATE_GW = generateRSAKeyPair()
     val PRIVATE_ENDPOINT = generateRSAKeyPair()
     val PDA_GRANTEE = generateRSAKeyPair()

--- a/src/test/kotlin/tech/relaycorp/relaynet/utils/MockCertificateStore.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/utils/MockCertificateStore.kt
@@ -3,6 +3,7 @@ package tech.relaycorp.relaynet.utils
 import java.time.ZonedDateTime
 import tech.relaycorp.relaynet.keystores.CertificateStore
 import tech.relaycorp.relaynet.keystores.KeyStoreBackendException
+import tech.relaycorp.relaynet.pki.CertificationPath
 
 class MockCertificateStore(
     private val savingException: Throwable? = null,
@@ -24,6 +25,18 @@ class MockCertificateStore(
         data[subjectPrivateAddress to issuerPrivateAddress] =
             data[subjectPrivateAddress to issuerPrivateAddress].orEmpty() +
             listOf(Pair(leafCertificateExpiryDate, certificationPathData))
+    }
+
+    suspend fun forceSave(
+        certificationPath: CertificationPath,
+        issuerPrivateAddress: String
+    ) {
+        saveData(
+            certificationPath.leafCertificate.subjectPrivateAddress,
+            certificationPath.leafCertificate.expiryDate,
+            certificationPath.serialize(),
+            issuerPrivateAddress
+        )
     }
 
     override suspend fun retrieveData(

--- a/src/test/kotlin/tech/relaycorp/relaynet/utils/MockCertificateStore.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/utils/MockCertificateStore.kt
@@ -14,34 +14,34 @@ class MockCertificateStore(
         mutableMapOf()
 
     override suspend fun saveData(
-        subjectPrivateAddress: String,
+        subjectId: String,
         leafCertificateExpiryDate: ZonedDateTime,
         certificationPathData: ByteArray,
-        issuerPrivateAddress: String
+        issuerId: String
     ) {
         if (savingException != null) {
             throw KeyStoreBackendException("Saving certificates isn't supported", savingException)
         }
-        data[subjectPrivateAddress to issuerPrivateAddress] =
-            data[subjectPrivateAddress to issuerPrivateAddress].orEmpty() +
+        data[subjectId to issuerId] =
+            data[subjectId to issuerId].orEmpty() +
             listOf(Pair(leafCertificateExpiryDate, certificationPathData))
     }
 
     suspend fun forceSave(
         certificationPath: CertificationPath,
-        issuerPrivateAddress: String
+        issuerId: String
     ) {
         saveData(
             certificationPath.leafCertificate.subjectId,
             certificationPath.leafCertificate.expiryDate,
             certificationPath.serialize(),
-            issuerPrivateAddress
+            issuerId
         )
     }
 
     override suspend fun retrieveData(
-        subjectPrivateAddress: String,
-        issuerPrivateAddress: String
+        subjectId: String,
+        issuerId: String
     ): List<ByteArray> {
         if (retrievalException != null) {
             throw KeyStoreBackendException(
@@ -49,7 +49,7 @@ class MockCertificateStore(
                 retrievalException
             )
         }
-        return data[subjectPrivateAddress to issuerPrivateAddress].orEmpty().map { it.second }
+        return data[subjectId to issuerId].orEmpty().map { it.second }
     }
 
     override suspend fun deleteExpired() {
@@ -58,7 +58,7 @@ class MockCertificateStore(
         }
     }
 
-    override fun delete(subjectPrivateAddress: String, issuerPrivateAddress: String) {
-        data.remove(subjectPrivateAddress to issuerPrivateAddress)
+    override fun delete(subjectId: String, issuerId: String) {
+        data.remove(subjectId to issuerId)
     }
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/utils/MockCertificateStore.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/utils/MockCertificateStore.kt
@@ -32,7 +32,7 @@ class MockCertificateStore(
         issuerPrivateAddress: String
     ) {
         saveData(
-            certificationPath.leafCertificate.subjectPrivateAddress,
+            certificationPath.leafCertificate.subjectId,
             certificationPath.leafCertificate.expiryDate,
             certificationPath.serialize(),
             issuerPrivateAddress

--- a/src/test/kotlin/tech/relaycorp/relaynet/utils/MockPrivateKeyStore.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/utils/MockPrivateKeyStore.kt
@@ -19,23 +19,23 @@ class MockPrivateKeyStore(
     }
 
     override suspend fun saveIdentityKeyData(
-        privateAddress: String,
+        nodeId: String,
         keyData: PrivateKeyData
     ) {
         if (savingException != null) {
             throw KeyStoreBackendException("Saving identity keys isn't supported", savingException)
         }
-        setIdentityKey(privateAddress, keyData)
+        setIdentityKey(nodeId, keyData)
     }
 
     /**
      * Set an identity key, bypassing all the usual validation.
      */
-    fun setIdentityKey(privateAddress: String, keyData: PrivateKeyData) {
-        identityKeys[privateAddress] = keyData
+    fun setIdentityKey(nodeId: String, keyData: PrivateKeyData) {
+        identityKeys[nodeId] = keyData
     }
 
-    override suspend fun retrieveIdentityKeyData(privateAddress: String): PrivateKeyData? {
+    override suspend fun retrieveIdentityKeyData(nodeId: String): PrivateKeyData? {
         if (retrievalException != null) {
             throw KeyStoreBackendException(
                 "Retrieving identity keys isn't supported",
@@ -43,7 +43,7 @@ class MockPrivateKeyStore(
             )
         }
 
-        return identityKeys[privateAddress]
+        return identityKeys[nodeId]
     }
 
     override suspend fun retrieveAllIdentityKeyData() = identityKeys.values.toList()
@@ -51,34 +51,34 @@ class MockPrivateKeyStore(
     override suspend fun saveSessionKeySerialized(
         keyId: String,
         keySerialized: ByteArray,
-        privateAddress: String,
-        peerPrivateAddress: String?
+        nodeId: String,
+        peerId: String?
     ) {
         if (savingException != null) {
             throw KeyStoreBackendException("Saving session keys isn't supported", savingException)
         }
-        setSessionKey(privateAddress, peerPrivateAddress, keyId, keySerialized)
+        setSessionKey(nodeId, peerId, keyId, keySerialized)
     }
 
     /**
      * Set a session key, bypassing all the usual validation.
      */
     fun setSessionKey(
-        privateAddress: String,
-        peerPrivateAddress: String?,
+        nodeId: String,
+        peerId: String?,
         keyId: String,
         keySerialized: ByteArray
     ) {
-        sessionKeys.putIfAbsent(privateAddress, mutableMapOf())
-        val peerKey = peerPrivateAddress ?: "unbound"
-        sessionKeys[privateAddress]!!.putIfAbsent(peerKey, mutableMapOf())
-        sessionKeys[privateAddress]!![peerKey]!![keyId] = keySerialized
+        sessionKeys.putIfAbsent(nodeId, mutableMapOf())
+        val peerKey = peerId ?: "unbound"
+        sessionKeys[nodeId]!!.putIfAbsent(peerKey, mutableMapOf())
+        sessionKeys[nodeId]!![peerKey]!![keyId] = keySerialized
     }
 
     override suspend fun retrieveSessionKeySerialized(
         keyId: String,
-        privateAddress: String,
-        peerPrivateAddress: String,
+        nodeId: String,
+        peerId: String,
     ): ByteArray? {
         if (retrievalException != null) {
             throw KeyStoreBackendException(
@@ -87,18 +87,18 @@ class MockPrivateKeyStore(
             )
         }
 
-        return sessionKeys[privateAddress]?.get(peerPrivateAddress)?.get(keyId)
-            ?: sessionKeys[privateAddress]?.get("unbound")?.get(keyId)
+        return sessionKeys[nodeId]?.get(peerId)?.get(keyId)
+            ?: sessionKeys[nodeId]?.get("unbound")?.get(keyId)
     }
 
-    override suspend fun deleteKeys(privateAddress: String) {
-        identityKeys.remove(privateAddress)
-        sessionKeys.remove(privateAddress)
+    override suspend fun deleteKeys(nodeId: String) {
+        identityKeys.remove(nodeId)
+        sessionKeys.remove(nodeId)
     }
 
-    override suspend fun deleteSessionKeysForPeer(peerPrivateAddress: String) {
+    override suspend fun deleteSessionKeysForPeer(peerId: String) {
         sessionKeys.values.forEach {
-            it.remove(peerPrivateAddress)
+            it.remove(peerId)
         }
     }
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/utils/MockSessionPublicKeyStore.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/utils/MockSessionPublicKeyStore.kt
@@ -13,22 +13,22 @@ class MockSessionPublicKeyStore(
         keys.clear()
     }
 
-    override suspend fun saveKeyData(keyData: SessionPublicKeyData, peerPrivateAddress: String) {
+    override suspend fun saveKeyData(keyData: SessionPublicKeyData, peerId: String) {
         if (savingException != null) {
             throw savingException
         }
-        this.keys[peerPrivateAddress] = keyData
+        this.keys[peerId] = keyData
     }
 
-    override suspend fun retrieveKeyData(peerPrivateAddress: String): SessionPublicKeyData? {
+    override suspend fun retrieveKeyData(peerId: String): SessionPublicKeyData? {
         if (retrievalException != null) {
             throw retrievalException
         }
 
-        return keys[peerPrivateAddress]
+        return keys[peerId]
     }
 
-    override suspend fun delete(peerPrivateAddress: String) {
-        keys.remove(peerPrivateAddress)
+    override suspend fun delete(peerId: String) {
+        keys.remove(peerId)
     }
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/utils/PDACertPath.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/utils/PDACertPath.kt
@@ -6,24 +6,24 @@ import tech.relaycorp.relaynet.issueEndpointCertificate
 import tech.relaycorp.relaynet.issueGatewayCertificate
 
 /**
- * Full certification path from a public gateway to a PDA.
+ * Full certification path from an Internet gateway to a PDA.
  */
 object PDACertPath {
     private val now: ZonedDateTime = ZonedDateTime.now()
     private val twoSecondsAgo = now.minusSeconds(2)
     private val tomorrow = now.plusDays(1)
 
-    val PUBLIC_GW = issueGatewayCertificate(
-        KeyPairSet.PUBLIC_GW.public,
-        KeyPairSet.PUBLIC_GW.private,
+    val INTERNET_GW = issueGatewayCertificate(
+        KeyPairSet.INTERNET_GW.public,
+        KeyPairSet.INTERNET_GW.private,
         tomorrow,
         validityStartDate = twoSecondsAgo
     )
     val PRIVATE_GW = issueGatewayCertificate(
         KeyPairSet.PRIVATE_GW.public,
-        KeyPairSet.PUBLIC_GW.private,
+        KeyPairSet.INTERNET_GW.private,
         tomorrow,
-        PUBLIC_GW,
+        INTERNET_GW,
         twoSecondsAgo
     )
     val PRIVATE_ENDPOINT = issueEndpointCertificate(

--- a/src/test/kotlin/tech/relaycorp/relaynet/utils/RAMFStubs.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/utils/RAMFStubs.kt
@@ -1,0 +1,9 @@
+package tech.relaycorp.relaynet.utils
+
+import tech.relaycorp.relaynet.messages.Recipient
+
+object RAMFStubs {
+    val recipientId = PDACertPath.PRIVATE_ENDPOINT.subjectId
+    val recipient = Recipient(recipientId)
+    const val recipientInternetAddress = "braavos.relaycorp.cloud"
+}

--- a/src/test/kotlin/tech/relaycorp/relaynet/utils/RAMFUtils.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/utils/RAMFUtils.kt
@@ -1,6 +1,0 @@
-package tech.relaycorp.relaynet.utils
-
-object RAMFUtils {
-    const val recipientId = "0deadbeef"
-    const val recipientInternetAddress = "braavos.relaycorp.cloud"
-}

--- a/src/test/kotlin/tech/relaycorp/relaynet/utils/RAMFUtils.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/utils/RAMFUtils.kt
@@ -1,0 +1,6 @@
+package tech.relaycorp.relaynet.utils
+
+object RAMFUtils {
+    const val recipientId = "0deadbeef"
+    const val recipientInternetAddress = "braavos.relaycorp.cloud"
+}

--- a/src/test/kotlin/tech/relaycorp/relaynet/utils/StubEncryptedRAMFMessage.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/utils/StubEncryptedRAMFMessage.kt
@@ -3,13 +3,14 @@ package tech.relaycorp.relaynet.utils
 import java.io.InputStream
 import java.nio.charset.Charset
 import java.time.ZonedDateTime
+import tech.relaycorp.relaynet.messages.Recipient
 import tech.relaycorp.relaynet.ramf.EncryptedRAMFMessage
 import tech.relaycorp.relaynet.ramf.RAMFMessageCompanion
 import tech.relaycorp.relaynet.ramf.RAMFSerializer
 import tech.relaycorp.relaynet.wrappers.x509.Certificate
 
 internal class StubEncryptedRAMFMessage(
-    recipientAddress: String,
+    recipient: Recipient,
     payload: ByteArray,
     senderCertificate: Certificate,
     messageId: String? = null,
@@ -18,7 +19,7 @@ internal class StubEncryptedRAMFMessage(
     senderCertificateChain: Set<Certificate>? = null
 ) : EncryptedRAMFMessage<StubEncryptedPayload>(
     SERIALIZER,
-    recipientAddress,
+    recipient,
     payload,
     senderCertificate,
     messageId,

--- a/src/test/kotlin/tech/relaycorp/relaynet/wrappers/KeysTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/wrappers/KeysTest.kt
@@ -245,23 +245,19 @@ class KeysTest {
     }
 
     @Nested
-    inner class PrivateAddress {
+    inner class NodeId {
         @Test
         fun `Private node address should be calculated from public key`() {
             val keyPair = generateRSAKeyPair()
 
-            val privateAddress = keyPair.public.privateAddress
-
-            assertEquals("0${sha256Hex(keyPair.public.encoded)}", privateAddress)
+            assertEquals("0${sha256Hex(keyPair.public.encoded)}", keyPair.public.nodeId)
         }
 
         @Test
         fun `Private node address should be calculated from private key`() {
             val keyPair = generateRSAKeyPair()
 
-            val privateAddress = keyPair.private.privateAddress
-
-            assertEquals("0${sha256Hex(keyPair.public.encoded)}", privateAddress)
+            assertEquals("0${sha256Hex(keyPair.public.encoded)}", keyPair.private.nodeId)
         }
     }
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/wrappers/x509/CertificateTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/wrappers/x509/CertificateTest.kt
@@ -638,7 +638,7 @@ class CertificateTest {
         }
 
         @Test
-        fun subjectPrivateAddress() {
+        fun subjectId() {
             val certificate = Certificate.issue(
                 subjectCommonName,
                 subjectKeyPair.public,
@@ -647,7 +647,7 @@ class CertificateTest {
             )
 
             val expectedAddress = "0${sha256Hex(subjectKeyPair.public.encoded)}"
-            assertEquals(expectedAddress, certificate.subjectPrivateAddress)
+            assertEquals(expectedAddress, certificate.subjectId)
         }
 
         @Test
@@ -738,7 +738,6 @@ class CertificateTest {
             validityEndDate
         )
 
-        @Suppress("ReplaceCallWithBinaryOperator")
         @Test
         fun `A non-Certificate object should not equal`() {
             assertFalse(stubCertificate.equals("Hey"))


### PR DESCRIPTION
Part of https://github.com/relaycorp/relayverse/issues/19, and JVM counterpart to https://github.com/relaycorp/relaynet-core-js/pull/491.

- [x] Implement `RecipientAddressing` class
- [x] Reimplement `RAMFMessage.recipient` as a `RecipientAddressing`
- [x] Remove `RAMFMessage.isRecipientAddressPrivate`
- [x] Remove `https://` prefix from Internet addresses
- [x] Rename "private address" -> "id"
- [x] Rename "public address" -> "internet address"
- [x] Rename "public gateway" -> "internet gateway"
- [x] Check compatibility with JS implementation
