### PR TITLE
fix: Migrate OID to one assigned to Relaycorp, Inc. by IANA

### DIFF
--- a/src/main/kotlin/tech/relaycorp/relaynet/OIDs.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/OIDs.kt
@@ -3,8 +3,10 @@ package tech.relaycorp.relaynet
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
 
 internal object OIDs {
+    // iso.org.dod.internet.private.enterprise.relaycorp
     private val RELAYCORP: ASN1ObjectIdentifier =
-        ASN1ObjectIdentifier("0.4.0.127.0.17").intern()
+        ASN1ObjectIdentifier("1.3.6.1.4.1.58708").intern()
+
     private val AWALA = RELAYCORP.branch("0").intern()
 
     private val AWALA_PKI = AWALA.branch("1").intern()

--- a/src/test/kotlin/tech/relaycorp/relaynet/wrappers/cms/EnvelopedDataTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/wrappers/cms/EnvelopedDataTest.kt
@@ -52,7 +52,7 @@ import tech.relaycorp.relaynet.wrappers.generateRSAKeyPair
 
 private val PLAINTEXT = "hello".toByteArray()
 
-private val ORIGINATOR_KEY_ID_OID = ASN1ObjectIdentifier("0.4.0.127.0.17.0.1.0")
+private val ORIGINATOR_KEY_ID_OID = ASN1ObjectIdentifier("1.3.6.1.4.1.58708.0.1.0")
 
 private val SENDER_SESSION_KEY_PAIR = SessionKeyPair.generate()
 


### PR DESCRIPTION
Replacing the one assigned to Relaycorp, Ltd. in the UK.

JS counterpart: https://github.com/relaycorp/relaynet-core-js/pull/503