### PR TITLE
fix(deps): Downgrade org.jetbrains.kotlin.jvm from 1.9.0 to 1.8.22

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ group = "tech.relaycorp"
 
 plugins {
     // Apply the Kotlin JVM plugin to add support for Kotlin.
-    id("org.jetbrains.kotlin.jvm") version "1.9.0"
+    id("org.jetbrains.kotlin.jvm") version "1.8.22"
 
     // Apply the java-library plugin for API and implementation separation.
     `java-library`


### PR DESCRIPTION
Reverts relaycorp/awala-jvm#287

Kotlin 1.9 isn't yet supported on Android